### PR TITLE
fix: ensure we do not match selector preview

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,6 +214,10 @@ async function launchContext(options: Options, headless: boolean): Promise<{ bro
     context.setDefaultTimeout(parseInt(options.timeout, 10));
     context.setDefaultNavigationTimeout(parseInt(options.timeout, 10));
   }
+
+  // Omit options that we add automatically for presentation purpose.
+  delete launchOptions.headless;
+  delete contextOptions.deviceScaleFactor;
   return { browser, browserName: browserType.name(), context, contextOptions, launchOptions };
 }
 

--- a/src/recorder/terminalOutput.ts
+++ b/src/recorder/terminalOutput.ts
@@ -36,8 +36,8 @@ export class TerminalOutput {
       const { ${browserName} } = require('playwright');
 
       (async() => {
-        const browser = await ${browserName}.launch(${formatObject(launchOptions)});
-        const context = await browser.newContext(${formatObject(contextOptions)});
+        const browser = await ${browserName}.launch(${formatObjectOrVoid(launchOptions)});
+        const context = await browser.newContext(${formatObjectOrVoid(contextOptions)});
         const page = await context.newPage();
       })();`);
     this._out.write(this._highlight(formatter.format()) + '\n');
@@ -54,7 +54,7 @@ export class TerminalOutput {
     highlightedCode = highlightedCode.replace(/<span class="hljs-comment">/g, '\x1b[38;5;23m');
     highlightedCode = highlightedCode.replace(/<\/span>/g, '\x1b[0m');
     highlightedCode = highlightedCode.replace(/&#x27;/g, "'");
-    highlightedCode = highlightedCode.replace(/&quot;/g, '"');    
+    highlightedCode = highlightedCode.replace(/&quot;/g, '"');
     highlightedCode = highlightedCode.replace(/&gt;/g, '>');
     highlightedCode = highlightedCode.replace(/&lt;/g, '<');
     return highlightedCode;
@@ -224,4 +224,9 @@ function formatObject(value: any, indent = '  '): string {
     return `{\n${indent}${tokens.join(`,\n${indent}`)}\n}`;
   }
   return String(value);
+}
+
+function formatObjectOrVoid(value: any, indent = '  '): string {
+  const result = formatObject(value, indent);
+  return result === '{}' ? '' : result;
 }


### PR DESCRIPTION
Sometimes, the text selector we generate like `text=/.*Search.*/` matches the selector preview element we add to the page. To avoid this put our highlight and preview in a closed shadow root.

Drive-by: also fix the NPE when `_hoveredSelector` is undefined.

Fixes #13. Might help with #16.