### PR TITLE
fix(codegen): click before throttler init lead to crash

### DIFF
--- a/src/recorder/injected/recorderScript.ts
+++ b/src/recorder/injected/recorderScript.ts
@@ -108,7 +108,7 @@ export default class RecorderScript {
         return;
     }
 
-    if (!this._consumeForAction(event))
+    if (!this._consumeForAction(event) || !this._hoveredSelector)
       return;
 
     this._performAction({


### PR DESCRIPTION
Before that change it lead to the following crash:

```
(node:77298) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'replace' of null
    at Object.quote (/Users/max.schmitt/Development/playwright-cli/lib/recorder/formatter.js:54:28)
    at TerminalOutput._generateActionCall (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:160:49)
    at TerminalOutput._generateAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:136:33)
    at TerminalOutput._printAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:92:37)
    at TerminalOutput.addAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:81:14)
    at RecorderController._recordAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/recorderController.js:83:22)
    at RecorderController._performAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/recorderController.js:58:14)
    at /Users/max.schmitt/Development/playwright-cli/lib/recorder/recorderController.js:31:83
    at BindingCall.call (/Users/max.schmitt/Development/playwright-cli/node_modules/playwright/lib/client/page.js:485:34)
    at ChromiumBrowserContext._onBinding (/Users/max.schmitt/Development/playwright-cli/node_modules/playwright/lib/client/browserContext.js:69:21)
(node:77298) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:77298) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non(node:77298) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'replace' of undefined
    at Object.quote (/Users/max.schmitt/Development/playwright-cli/lib/recorder/formatter.js:54:28)
    at TerminalOutput._generateActionCall (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:160:49)
    at TerminalOutput._generateAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:136:33)
    at TerminalOutput._printAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:92:37)
    at TerminalOutput.addAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/terminalOutput.js:81:14)
    at RecorderController._recordAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/recorderController.js:83:22)
    at RecorderController._performAction (/Users/max.schmitt/Development/playwright-cli/lib/recorder/recorderController.js:58:14)
```

when the user tried to click directly multiple times on the page before our script / highlighter was initialised.