### PR TITLE
fix(selectors): do not produce a selector that targets a very large parent

### DIFF
--- a/src/recorder/injected/selectorGenerator.ts
+++ b/src/recorder/injected/selectorGenerator.ts
@@ -19,6 +19,7 @@ import { XPathEngine } from './xpathSelectorEngine';
 export async function buildSelector(targetElement: Element): Promise<string> {
   const path: SelectorToken[] = [];
   let numberOfMatchingElements = Number.MAX_SAFE_INTEGER;
+  const targetBox = targetElement.getBoundingClientRect();
   for (let element: Element | null = targetElement; element && element !== document.documentElement; element = element.parentElement) {
     const selector = buildSelectorCandidate(element);
     if (!selector)
@@ -26,6 +27,9 @@ export async function buildSelector(targetElement: Element): Promise<string> {
     const fullSelector = joinSelector([selector, ...path]);
     const selectorTargets = await window.queryPlaywrightSelector(fullSelector);
     if (!selectorTargets.length)
+      break;
+    const resolvedBox = selectorTargets[0].getBoundingClientRect();
+    if (resolvedBox.width > targetBox.width * 2 && resolvedBox.height > targetBox.height * 2)
       break;
     if (selectorTargets[0].contains(targetElement))
       return fullSelector;

--- a/test/selectors.spec.ts
+++ b/test/selectors.spec.ts
@@ -119,3 +119,15 @@ it('should use nested ordinals', async ({ pageWrapper }) => {
   const selector = await pageWrapper.hoverOverElement('c[mark="1"]');
   expect(selector).toBe('//b[2]/c');
 });
+
+it('should use the parent with data-testid', async ({ pageWrapper }) => {
+  await pageWrapper.setContentAndWait(`<div>Text</div><div data-testid=a><img style="width: 200px; height: 200px;"/></div>`);
+  const selector = await pageWrapper.hoverOverElement('img');
+  expect(selector).toBe('div[data-testid="a"]');
+});
+
+it('should not use a very large parent', async ({ pageWrapper }) => {
+  await pageWrapper.setContentAndWait(`<div style="height: 600px" data-testid=a><img style="width: 200px; height: 200px;"/></div>`);
+  const selector = await pageWrapper.hoverOverElement('img');
+  expect(selector).toBe('//img');
+});


### PR DESCRIPTION
In this case, fallback to more precise xpath instead of clicking at the wrong target.

This addresses "https://theverge.com" case from issue #2.