### PR TITLE
fix(codegen): input attribute prioritisation

### DIFF
--- a/src/recorder/injected/selectorGenerator.ts
+++ b/src/recorder/injected/selectorGenerator.ts
@@ -50,10 +50,10 @@ function buildSelectorCandidate(element: Element): SelectorToken | null {
   if (element.nodeName === 'INPUT') {
     if (element.getAttribute('name'))
       return { engine: 'css', selector: `input[name=${quoteString(element.getAttribute('name')!)}]` };
+    if (element.getAttribute('placeholder'))
+      return { engine: 'css', selector: `input[placeholder=${quoteString(element.getAttribute('placeholder')!)}]` };
     if (element.getAttribute('type'))
       return { engine: 'css', selector: `input[type=${quoteString(element.getAttribute('type')!)}]` };
-    if (element.getAttribute('placeholder'))
-       return { engine: 'css', selector: `input[placeholder=${quoteString(element.getAttribute('placeholder')!)}]` };
   } else if (element.nodeName === 'IMG') {
     if (element.getAttribute('alt'))
       return { engine: 'css', selector: `img[alt=${quoteString(element.getAttribute('alt')!)}]` };

--- a/test/selectors.spec.ts
+++ b/test/selectors.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { it, expect } from './playwright.fixtures';
+import { it, expect, describe } from './playwright.fixtures';
 
 it('should generate for text', async ({ pageWrapper }) => {
   await pageWrapper.setContentAndWait(`<div>Text</div>`);
@@ -119,3 +119,18 @@ it('should use nested ordinals', async ({ pageWrapper }) => {
   const selector = await pageWrapper.hoverOverElement('c[mark="1"]');
   expect(selector).toBe('//b[2]/c');
 });
+
+describe("should prioritise input element attributes correctly", () => {
+  it('name', async ({ pageWrapper }) => {
+    await pageWrapper.setContentAndWait(`<input name="foobar" type="text"/>`);
+    expect(await pageWrapper.hoverOverElement('input')).toBe('input[name="foobar"]');
+  });
+  it('placeholder', async ({ pageWrapper }) => {
+    await pageWrapper.setContentAndWait(`<input placeholder="foobar" type="text"/>`);
+    expect(await pageWrapper.hoverOverElement('input')).toBe('input[placeholder="foobar"]');
+  });
+  it('type', async ({ pageWrapper }) => {
+    await pageWrapper.setContentAndWait(`<input type="text"/>`);
+    expect(await pageWrapper.hoverOverElement('input')).toBe('input[type="text"]');
+  });
+})


### PR DESCRIPTION
Before a input element with a placeholder resulted in `input[type=text]`. Experienced on an internal project site.