### PR TITLE
fix(codegen): do not record multiple actions at once

### DIFF
--- a/src/recorder/injected/recorderScript.ts
+++ b/src/recorder/injected/recorderScript.ts
@@ -24,6 +24,7 @@ declare global {
   interface Window {
     performPlaywrightAction: (action: actions.Action) => Promise<void>;
     recordPlaywrightAction: (action: actions.Action) => Promise<void>;
+    commitLastAction: () => Promise<void>;
     queryPlaywrightSelector: (selector: string) => Promise<Element[]>;
     playwrightRecorderScript: RecorderScript;
   }
@@ -93,7 +94,7 @@ export default class RecorderScript {
           max-width: 600px;
           padding: 3.2px 5.12px 3.2px;
           position: absolute;
-          top: 0;  
+          top: 0;
         }
     </style>
     `);
@@ -209,11 +210,7 @@ export default class RecorderScript {
     const { selector, elements } = await buildSelector(hoveredElement);
     if ((this._hoveredModel && this._hoveredModel.selector === selector) || this._hoveredElement !== hoveredElement)
       return;
-    this._performAction({
-      name: 'commit',
-      committed: true,
-      signals: [],
-    });
+    window.commitLastAction();
     this._hoveredModel = selector ? { selector, elements } : null;
     this._updateHighlight();
     if ((window as any)._highlightUpdatedForTest)

--- a/src/recorder/recorderActions.ts
+++ b/src/recorder/recorderActions.ts
@@ -18,7 +18,6 @@ export type ActionName =
   'check' |
   'click' |
   'closePage' |
-  'commit' |
   'fill' |
   'navigate' |
   'openPage' |
@@ -43,10 +42,6 @@ export type ClickAction = ActionBase & {
 export type CheckAction = ActionBase & {
   name: 'check',
   selector: string,
-};
-
-export type CommitAction = ActionBase &  {
-  name: 'commit',
 };
 
 export type UncheckAction = ActionBase & {
@@ -86,7 +81,7 @@ export type SelectAction = ActionBase & {
   options: string[],
 };
 
-export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | CommitAction;
+export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction;
 
 // Signals.
 
@@ -108,9 +103,7 @@ export function actionTitle(action: Action): string {
     case 'openPage':
       return `Open new page`;
     case 'closePage':
-        return `Close page`;
-    case 'commit':
-        return ``;
+      return `Close page`;
     case 'check':
       return `Check ${action.selector}`;
     case 'uncheck':

--- a/src/recorder/recorderController.ts
+++ b/src/recorder/recorderController.ts
@@ -40,6 +40,10 @@ export class RecorderController {
     context.exposeBinding('recordPlaywrightAction',
         (source: BindingSource, action: actions.Action) => this._recordAction(source.frame, source.page, action)).catch(e => {});
 
+    // Commits last action so that no furhter signals are added to it.
+    context.exposeBinding('commitLastAction',
+        (source: BindingSource, action: actions.Action) => this._commitLastAction()).catch(e => {});
+
     // Other non-essential actions are simply being recorded.
     context.exposeBinding('queryPlaywrightSelector', async (source: BindingSource, selector: string) => {
       return await source.frame.$$(selector).catch(e => []);
@@ -87,6 +91,12 @@ export class RecorderController {
           signals: [],
         });
     }
+  }
+
+  private _commitLastAction() {
+    const action = this._output.lastAction();
+    if (action)
+      action.committed = true;
   }
 
   private async _performAction(frame: playwright.Frame, page: playwright.Page, action: actions.Action) {

--- a/src/recorder/terminalOutput.ts
+++ b/src/recorder/terminalOutput.ts
@@ -61,11 +61,6 @@ export class TerminalOutput {
 
   addAction(pageAlias: string, frame: playwright.Frame, action: Action) {
     // We augment last action based on the type.
-    if (action.name === 'commit') {
-      if (this._lastAction)
-        this._lastAction.committed = true;
-      return;
-    }
     let eraseLastAction = false;
     if (this._lastAction && action.name === 'fill' && this._lastAction.name === 'fill') {
       if (action.selector === this._lastAction.selector)
@@ -191,8 +186,6 @@ export class TerminalOutput {
       }
       case 'check':
         return `check(${quote(action.selector)})`;
-      case 'commit':
-          return ``;
       case 'uncheck':
         return `uncheck(${quote(action.selector)})`;
       case 'fill':


### PR DESCRIPTION
We have a bug where "commit" action does not respect the "is performing action" flag and therefore may reset it.
This leads to action reentrancy and multiple clicks being performed/recorded per single user click.

Fixes #16.