### PR TITLE
tests: fixed failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright-cli",
   "homepage": "https://playwright.dev",
   "scripts": {
-    "test": "test-runner test/",
+    "test": "test-runner test/ --timeout 35000",
     "build": "node utils/runWebpack.js --mode='development' && tsc -p .",
     "watch": "node utils/runWebpack.js --mode='development' --watch --silent | tsc -w -p ."
   },

--- a/test/playwright.fixtures.ts
+++ b/test/playwright.fixtures.ts
@@ -34,6 +34,7 @@ type TestFixtures = {
 
 export const fixtures = baseFixtures.extend<WorkerFixtures, TestFixtures>();
 export const it = fixtures.it;
+export const fit = fixtures.fit;
 export const describe = fixtures.describe;
 export const expect = fixtures.expect;
 
@@ -180,10 +181,16 @@ class PageWrapper {
   }
 
   async hoverOverElement(selector: string): Promise<string> {
+    await this.page.waitForSelector(selector, {
+      state: 'attached'
+    });
     return this.waitForHighlight(() => this.page.dispatchEvent(selector, 'mousemove', { detail: 1 }));
   }
 
   async focusElement(selector: string): Promise<string> {
+    await this.page.waitForSelector(selector, {
+      state: 'attached'
+    });
     return this.waitForHighlight(() => this.page.focus(selector));
   }
 }

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -364,16 +364,20 @@ it('should handle dialogs', async ({ pageWrapper }) => {
   <button onclick="alert()">click me</button>
   `);
   await pageWrapper.hoverOverElement('button');
+  let resolveDialogDismissed;
+  const dialogDismissed = new Promise(resolve => resolveDialogDismissed = resolve);
   page.once('dialog', async dialog => {
     await dialog.dismiss();
+    resolveDialogDismissed();
   });
-  await page.click('text="click me"')
-  await output.waitFor("page.click")
+  await page.click('text="click me"');
+  await dialogDismissed;
+  await output.waitFor("page.click");
   expect(output.text()).toContain(`
   // Click text="click me"
   page.once('dialog', dialog => {
     console.log(\`Dialog message: $\{dialog.message()}\`);
     dialog.dismiss().catch(() => {});
   });
-  await page.click('text="click me"')`)
+  await page.click('text="click me"');`)
 });


### PR DESCRIPTION
Note: Since it's private the bots only run on branches which are on this repository.
Note: tested around 4-5 times and it passes all the time now.

Let's maybe increase the default timeout on the test runner to 35 seconds? (not 30 because this could still lead to test timeouts by that a not good error reporting. So the user has 5 seconds to do something).
This caused e.g. flaky tests on the playwright-cli for Firefox.