### PR TITLE
chore: fix build due case sensitive import

### DIFF
--- a/src/injected/script.ts
+++ b/src/injected/script.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ConsoleAPI, InjectedScript } from './consoleAPI';
+import { ConsoleAPI, InjectedScript } from './consoleApi';
 import { Recorder } from './recorder';
 
 export default class Script {


### PR DESCRIPTION
Files on Linux are case sensitive and webpack doesn't standardises that.