### PR TITLE
fix(cli): remove isMobile on Firefox

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -152,6 +152,10 @@ async function launchContext(options: Options, headless: boolean): Promise<{ bro
     delete contextOptions.isMobile;
   }
 
+  if (contextOptions.isMobile && browserType.name() === 'firefox') {
+    contextOptions.isMobile = undefined
+  }
+
   // Proxy
 
   if (options.proxyServer) {


### PR DESCRIPTION
Closes #54

Decided to not print a warning for now.