### PR TITLE
fix(codegen): print ampersand correctly

### DIFF
--- a/src/terminalOutput.ts
+++ b/src/terminalOutput.ts
@@ -68,6 +68,7 @@ export class TerminalOutput {
     highlightedCode = highlightedCode.replace(/&quot;/g, '"');
     highlightedCode = highlightedCode.replace(/&gt;/g, '>');
     highlightedCode = highlightedCode.replace(/&lt;/g, '<');
+    highlightedCode = highlightedCode.replace(/&amp;/g, '&');
     return highlightedCode;
   }
 


### PR DESCRIPTION
Went through the other relevant html entities, seems fine to me. 

https://github.com/highlightjs/highlight.js/blob/3e9c1b1e8b10b3a5c82ab6e52700ee51f5e978b0/src/lib/utils.js#L5-L11