### PR TITLE
fix(codegen): escape slashes correctly

### DIFF
--- a/src/codegen/languages/javascript.ts
+++ b/src/codegen/languages/javascript.ts
@@ -167,7 +167,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
         const browser = await ${browserName}.launch(${formatObjectOrVoid(launchOptions)});
         const context = await browser.newContext(${formatContextOptions(contextOptions, deviceName)});
       })();`);
-     this._output.write(formatter.format() + '\n');
+    this._output.write(formatter.format() + '\n');
   }
 
   writeFooter(): void {
@@ -266,12 +266,8 @@ class JavaScriptFormatter {
   }
 }
 
-function quote(text: string, char: string = '\'') {
-  if (char === '\'')
-    return char + text.replace(/[']/g, '\\\'') + char;
-  if (char === '"')
-    return char + text.replace(/["]/g, '\\"') + char;
-  if (char === '`')
-    return char + text.replace(/[`]/g, '\\`') + char;
-  throw new Error('Invalid escape char');
+const quoteChar = '\'';
+function quote(text: string): string {
+  return quoteChar + text.replace(/[']/g, '\\\'')
+    .replace(/\\/g, '\\\\') + quoteChar;
 }

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -36,6 +36,17 @@ it('should click', async ({ page, recorder }) => {
   expect(message.text()).toBe('click');
 });
 
+it('should escape slashes correctly for JavaScript', async ({ recorder, page }) => {
+  await recorder.setContentAndWait(`<button>username (first last) / Repositories</button>`);
+  const selector = await recorder.focusElement('button');
+  expect(selector).toBe('text=/.*username \\(first last\\) / Reposi.*/');
+  await page.click('text=username')
+  await recorder.waitForOutput('username')
+  expect(recorder.output()).toContain(`
+  // Click text=/.*username \\(first last\\) / Reposi.*/
+  await page.click('text=/.*username \\\\(first last\\\\) / Reposi.*/');`)
+});
+
 it('should not target selector preview by text regexp', async ({ page, recorder }) => {
   await recorder.setContentAndWait(`<span>dummy</span>`);
 


### PR DESCRIPTION
Not sure where the best place is to put in such a handling.
LanguageGenerators seems totally wrong, inside building the selectors won't work, since then Playwright won't find the element if we escape it in a variable. Maybe before we write it to the outputs replace `\\` by `\\\\`.

Found the issue when navigating through GitHub repositories.