### PR TITLE
fix(overlay): use max z-index for highlight

### DIFF
--- a/src/injected/recorder.ts
+++ b/src/injected/recorder.ts
@@ -53,7 +53,7 @@ export class Recorder {
         right: 0;
         bottom: 0;
         left: 0;
-        z-index: 1000000;
+        z-index: 2147483647;
         pointer-events: none;
         display: flex;
       ">


### PR DESCRIPTION
W3 Schools uses in their cookie popups a z-index of 1000000 which ends up that our highlights won't be shown. Using now the official max value.