### PR TITLE
fix(highlight): hide initial hightlight elment

### DIFF
--- a/src/injected/recorder.ts
+++ b/src/injected/recorder.ts
@@ -82,7 +82,7 @@ export class Recorder {
                       rgba(0, 0, 0, 0.15) 0px -12.1px 24px,
                       rgba(0, 0, 0, 0.25) 0px 54px 55px;
           color: rgb(204, 204, 204);
-          display: flex;
+          display: none;
           font-family: 'Dank Mono', 'Operator Mono', Inconsolata, 'Fira Mono',
                        'SF Mono', Monaco, 'Droid Sans Mono', 'Source Code Pro', monospace;
           font-size: 12.8px;


### PR DESCRIPTION
Since we overwrite the style properties on-demand it should be fine.

Previously if no element was highlighted it looked like that (top left) in the beginning which might confuse users:

![image](https://user-images.githubusercontent.com/17984549/94277793-5790ed80-ff4a-11ea-84d2-7fe28f033cc0.png)
