### PR TITLE
Corrects typo in pdf command example.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,7 +114,7 @@ program
       console.log('');
       console.log('Examples:');
       console.log('');
-      console.log('  $ pdf https://example.com example.png');
+      console.log('  $ pdf https://example.com example.pdf');
     });
 
 if (process.env.PWTRACE) {


### PR DESCRIPTION
Issue #90 This corrects a typo in help text. 