### PR TITLE
feat(codegen): generate selectors in shadow dom

### DIFF
--- a/src/injected/consoleApi.ts
+++ b/src/injected/consoleApi.ts
@@ -27,6 +27,7 @@ export type ParsedSelector = {
 export interface InjectedScript {
   parseSelector(selector: string): ParsedSelector;
   engines: Set<string>;
+  querySelector(selector: ParsedSelector, document: Document): Element | undefined;
   querySelectorAll(selector: ParsedSelector, document: Document): Element[];
 };
 

--- a/test/selectors.spec.ts
+++ b/test/selectors.spec.ts
@@ -132,7 +132,7 @@ it('should not use input[value]', async ({ recorder }) => {
   expect(selector).toBe('//input[2]');
 });
 
-describe("should prioritise input element attributes correctly", () => {
+describe('should prioritise input element attributes correctly', () => {
   it('name', async ({ recorder }) => {
     await recorder.setContentAndWait(`<input name="foobar" type="text"/>`);
     expect(await recorder.hoverOverElement('input')).toBe('input[name="foobar"]');
@@ -145,4 +145,47 @@ describe("should prioritise input element attributes correctly", () => {
     await recorder.setContentAndWait(`<input type="text"/>`);
     expect(await recorder.hoverOverElement('input')).toBe('input[type="text"]');
   });
-})
+});
+
+it('should find text in shadow dom', async ({ recorder }) => {
+  await recorder.setContentAndWait(`<div></div>`);
+  await recorder.page.$eval('div', div => {
+    const shadowRoot = div.attachShadow({ mode: 'open' });
+    const span = document.createElement('span');
+    span.textContent = 'Target';
+    shadowRoot.appendChild(span);
+  });
+  const selector = await recorder.hoverOverElement('span');
+  expect(selector).toBe('text="Target"');
+});
+
+it('should fallback to css in shadow dom', async ({ recorder }) => {
+  await recorder.setContentAndWait(`<div></div>`);
+  await recorder.page.$eval('div', div => {
+    const shadowRoot = div.attachShadow({ mode: 'open' });
+    const input = document.createElement('input');
+    shadowRoot.appendChild(input);
+  });
+  const selector = await recorder.hoverOverElement('input');
+  expect(selector).toBe('input');
+});
+
+it('should fallback to css in deep shadow dom', async ({ recorder }) => {
+  recorder.page.on('console', console.log);
+  await recorder.setContentAndWait(`<div></div><div></div><div><input></div>`);
+  await recorder.page.$eval('div', div1 => {
+    const shadowRoot1 = div1.attachShadow({ mode: 'open' });
+    const input1 = document.createElement('input');
+    shadowRoot1.appendChild(input1);
+    const divExtra3 = document.createElement('div');
+    shadowRoot1.append(divExtra3);
+    const div2 = document.createElement('div');
+    shadowRoot1.append(div2);
+    const shadowRoot2 = div2.attachShadow({ mode: 'open' });
+    const input2 = document.createElement('input');
+    input2.setAttribute('value', 'foo');
+    shadowRoot2.appendChild(input2);
+  });
+  const selector = await recorder.hoverOverElement('input[value=foo]');
+  expect(selector).toBe('div div:nth-child(3) input');
+});


### PR DESCRIPTION
For elements in the shadow, we use css fallback instead of xpath, because xpath does not pierce shadow.

Fixes #60.