### PR TITLE
chore: reduce footer separator length

### DIFF
--- a/src/codegen/languages/javascript.ts
+++ b/src/codegen/languages/javascript.ts
@@ -151,7 +151,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
   }
 
   generateFooter(): string {
-    return `  //------------------------------------------------------------------------------
+    return `  // ---------------------
   await browser.close();
 })();`;
   }

--- a/src/codegen/languages/python.ts
+++ b/src/codegen/languages/python.ts
@@ -144,7 +144,7 @@ async def run(playwright) {
   }
 
   generateFooter(): string {
-    return `    #--------------------------------------------------------------------------------
+    return `    # ---------------------
     await browser.close()
 
 async def main():

--- a/test/codegen-js.spec.ts
+++ b/test/codegen-js.spec.ts
@@ -106,7 +106,7 @@ it('should save the codegen output to a file if specified', async ({ runCLI, tmp
   // Close page
   await page.close();
 
-  //------------------------------------------------------------------------------
+  // ---------------------
   await browser.close();
 })();`)
 });

--- a/test/codegen-py.spec.ts
+++ b/test/codegen-py.spec.ts
@@ -93,7 +93,7 @@ async def run(playwright):
     # Close page
     await page.close()
 
-    #--------------------------------------------------------------------------------
+    # ---------------------
     await browser.close()
 
 async def main():


### PR DESCRIPTION
Default terminal/iterm window width on macOS is smaller than the separator line length, which causes an ugly line break.