### PR TITLE
fix(install): avoid accidental removal of downloaded browsers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,7 +126,7 @@ program
     .description('Ensure browsers necessary for this version of Playwright are installed')
     .action(function(url, filename, command) {
       require('playwright/lib/install/installer').installBrowsersWithProgressBar(
-          path.dirname(require.resolve('playwright')));
+        path.dirname(process.execPath));
     });
 
 if (process.env.PWTRACE) {


### PR DESCRIPTION
Previously the back link from browser cache was pointing to a path inside pkg (`/snapshot/playwright-cli/node_modules/playwright/browsers.json`) which other playwright installers would fail to resolve. This change replaces it with a real path to browsers.json in the host filesystem similar to regular npm package installation.