### PR TITLE
fix: python code generator

### DIFF
--- a/src/codegen/languages/python.ts
+++ b/src/codegen/languages/python.ts
@@ -100,7 +100,7 @@ export class PythonLanguageGenerator implements LanguageGenerator {
     formatter.add(code);
 
     if (assertNavigation)
-      formatter.add(`  # assert ${pageAlias}.url() == ${quote(navigationSignal!.url)}`);
+      formatter.add(`  # assert ${pageAlias}.url == ${quote(navigationSignal!.url)}`);
     return formatter.format();
   }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-cli/issues/143
In python, url of page is used as a property not as a callable.
https://github.com/microsoft/playwright-python/blob/f11b984a648d1db5cfa4fcde705bbf79d034c90f/playwright/page.py#L429-L431