### PR TITLE
feat(trace viewer): support multiple contexts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,12 +142,13 @@ if (process.env.PWTRACE) {
     .description('Show trace viewer')
     .option('--resources <dir>', 'Directory with the shared trace artifacts')
     .action(function(trace, command) {
-      showTraceViewer(resolveHome(command.resources), resolveHome(trace));
+      showTraceViewer(resolveHome(command.resources), resolveHome(trace)!);
     }).on('--help', function() {
       console.log('');
       console.log('Examples:');
       console.log('');
-      console.log('  $ show-trace --resources=resources trace.trace');
+      console.log('  $ show-trace --resources=resources trace/file.trace');
+      console.log('  $ show-trace trace/directory');
     });
 }
 
@@ -343,7 +344,7 @@ async function codegen(options: Options, url: string | undefined, target: string
   switch (target) {
     case 'javascript': languageGenerator = new JavaScriptLanguageGenerator(); break;
     case 'csharp': languageGenerator = new CSharpLanguageGenerator(); break;
-    case 'python': 
+    case 'python':
     case 'python-async': languageGenerator = new PythonLanguageGenerator(target === 'python-async'); break;
     default: throw new Error(`Invalid target: '${target}'`);
   }
@@ -357,7 +358,7 @@ async function codegen(options: Options, url: string | undefined, target: string
   if (outputFile)
     outputs.push(new FileOutput(outputFile));
   const output = new OutputMultiplexer(outputs);
-  
+
   const generator = new CodeGenerator(browserName, launchOptions, contextOptions, output, languageGenerator, options.device);
   new ScriptController(context, generator);
   await openPage(context, url);
@@ -395,8 +396,8 @@ function validateOptions(options: Options) {
   }
 }
 
-function resolveHome(filepath: string) {
-  if (filepath[0] === '~')
+function resolveHome(filepath: string | undefined) {
+  if (filepath && filepath[0] === '~')
     return path.join(os.homedir(), filepath.slice(1));
   return filepath;
 }

--- a/src/traceViewer/traceModel.ts
+++ b/src/traceViewer/traceModel.ts
@@ -38,6 +38,7 @@ export type PageEntry = {
 }
 
 export type ActionEntry = {
+  actionId: string;
   action: trace.ActionTraceEvent;
   resources: trace.NetworkResourceTraceEvent[];
 }

--- a/src/traceViewer/traceModel.ts
+++ b/src/traceViewer/traceModel.ts
@@ -17,13 +17,14 @@
 import * as trace from "./traceTypes";
 
 export type TraceModel = {
-  fileName: string;
   contexts: ContextEntry[];
-  startTime: number;
-  endTime: number;
 }
 
 export type ContextEntry = {
+  name: string;
+  filePath: string;
+  startTime: number;
+  endTime: number;
   created: trace.ContextCreatedTraceEvent;
   destroyed: trace.ContextDestroyedTraceEvent;
   pages: PageEntry[];

--- a/src/traceViewer/videoTileGenerator.ts
+++ b/src/traceViewer/videoTileGenerator.ts
@@ -23,13 +23,7 @@ import { PageVideoTraceEvent } from './traceTypes';
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
 
 export class VideoTileGenerator {
-  private _traceStorageDir: string;
-
-  constructor(traceStorageDir: string) {
-    this._traceStorageDir = traceStorageDir;
-  }
-
-  async render(events: PageVideoTraceEvent[]) {
+  async render(events: PageVideoTraceEvent[], videoDir: string) {
     let ffmpegName = '';
     if (process.platform === 'win32') {
       if (process.arch === 'ia32')
@@ -43,7 +37,7 @@ export class VideoTileGenerator {
       ffmpegName = 'ffmpeg-linux';
     const ffmpeg = path.join(path.dirname(require.resolve('playwright')), 'third_party', 'ffmpeg', ffmpegName);
     for (const event of events) {
-      const fileName = path.join(this._traceStorageDir, event.fileName);
+      const fileName = path.join(videoDir, event.fileName);
       if (fs.existsSync(fileName + '-metainfo.txt'))
         continue;
       console.log('Generating frames for ' + fileName);

--- a/src/traceViewer/web/ui/actionListView.ts
+++ b/src/traceViewer/web/ui/actionListView.ts
@@ -36,7 +36,7 @@ export class ActionListView {
   }
 
   render(actionEntry: ActionEntry, element: HTMLElement): HTMLElement {
-    const { action } = actionEntry;
+    const { action, actionId } = actionEntry;
     if (element) {
       return element;
     }
@@ -49,7 +49,7 @@ export class ActionListView {
         </action-header>
         <action-thumbnail>
           ${action.snapshot ?
-            dom`<img src="trace-storage/${action.snapshot.sha1}-thumbnail.png">` :
+            dom`<img src="action-preview/${actionId}.png">` :
             dom`No snapshot available`
           }
         </action-thumbnail>

--- a/src/traceViewer/web/ui/workbench.css
+++ b/src/traceViewer/web/ui/workbench.css
@@ -1,12 +1,12 @@
 /*
   Copyright (c) Microsoft Corporation.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
       http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,25 @@
 .workbench .product {
   font-weight: 600;
   margin-left: 16px;
+}
+
+.workbench .spacer {
+  flex: auto;
+}
+
+.workbench .context-selector {
+  min-width: 38px;
+  border: 1px solid transparent;
+  border-radius: 0;
+  padding: 0 13px 0 5px;
+  position: relative;
+  height: 22px;
+  align-self: center;
+  margin-right: 20px;
+  background: rgba(222, 222, 222, 0.3);
+  color: white;
+  border-radius: 3px;
+  outline: none !important;
 }
 
 tab-strip {

--- a/src/traceViewer/web/ui/workbench.ts
+++ b/src/traceViewer/web/ui/workbench.ts
@@ -34,6 +34,8 @@ export class Workbench {
     this._contextSelector.addEventListener('input', () => {
       this.showContext(trace.contexts[this._contextSelector.selectedIndex]);
     });
+    if (trace.contexts.length === 1)
+      this._contextSelector.style.visibility = 'hidden';
     this.element = dom`
       <vbox class="workbench">
       </vbox>


### PR DESCRIPTION
We can now just point to a directory, and trace viewer will load all trace files from there.