### PR TITLE
feat(traceViewer): fix network and source tabs

### DIFF
--- a/src/traceViewer/traceModel.ts
+++ b/src/traceViewer/traceModel.ts
@@ -35,6 +35,7 @@ export type PageEntry = {
   destroyed: trace.PageDestroyedTraceEvent;
   video?: trace.PageVideoTraceEvent;
   actions: ActionEntry[];
+  resources: trace.NetworkResourceTraceEvent[];
 }
 
 export type ActionEntry = {

--- a/src/traceViewer/traceViewer.ts
+++ b/src/traceViewer/traceViewer.ts
@@ -79,7 +79,8 @@ class TraceViewer {
         case 'page-created': {
           const pageEntry: any = {
             created: event,
-            actions: []
+            actions: [],
+            resources: [],
           };
           pageEntries.set(event.pageId, pageEntry);
           contextEntries.get(event.contextId)!.pages.push(pageEntry);
@@ -95,19 +96,23 @@ class TraceViewer {
           break;
         }
         case 'action': {
-          const actions = pageEntries.get(event.pageId!)!.actions;
-          actions.push({
-            actionId: event.contextId + '/' + event.pageId + '/' + actions.length,
+          const pageEntry = pageEntries.get(event.pageId!)!;
+          const action: ActionEntry = {
+            actionId: event.contextId + '/' + event.pageId + '/' + pageEntry.actions.length,
             action: event,
-            resources: []
-          });
+            resources: pageEntry.resources,
+          };
+          pageEntry.resources = [];
+          pageEntry.actions.push(action);
           break;
         }
         case 'resource': {
-          const actions = pageEntries.get(event.pageId!)!.actions;
-          const action = actions[actions.length - 1];
+          const pageEntry = pageEntries.get(event.pageId!)!;
+          const action = pageEntry.actions[pageEntry.actions.length - 1];
           if (action)
             action.resources.push(event);
+          else
+            pageEntry.resources.push(event);
           let responseEvents = this._resources.get(event.url);
           if (!responseEvents) {
             responseEvents = [];

--- a/src/traceViewer/web/ui/sourceTab.ts
+++ b/src/traceViewer/web/ui/sourceTab.ts
@@ -45,12 +45,12 @@ export class SourceTab implements Tab {
     }
     const { action } = actionEntry;
     const frames = action.stack!.split('\n').slice(1);
-    const frame = frames.filter(frame => !frame.includes('playwright/lib/client/'))[0];
+    const frame = frames.filter(frame => !frame.includes('playwright/lib/') && !frame.includes('playwright/src/'))[0];
     if (!frame) {
       this._editor.setValue(action.stack!);
       return;
     }
-    const match = frame.match(/at ([^:]+):(\d+):\d+/);
+    const match = frame.match(/at [^(]+\(([^:]+):(\d+):\d+\)/) || frame.match(/at ([^:^(]+):(\d+):\d+/);
     if (!match) {
       this._editor.setValue(action.stack!);
       return;


### PR DESCRIPTION
Source now accounts for various stack trace formats.
Network now shows `page.goto` resources.