### PR TITLE
feat: save/load storage options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -280,6 +280,7 @@ async function launchContext(options: Options, headless: boolean): Promise<{ bro
     // a temporary page and we call closeBrowser again when that page closes.
     if (closingBrowser)
       return;
+    closingBrowser = true;
     if (options.saveStorage)
       await context.storageState({ path: options.saveStorage }).catch(e => null);
     await browser.close();
@@ -381,7 +382,7 @@ async function codegen(options: Options, url: string | undefined, target: string
     outputs.push(new FileOutput(outputFile));
   const output = new OutputMultiplexer(outputs);
 
-  const generator = new CodeGenerator(browserName, launchOptions, contextOptions, output, languageGenerator, options.device);
+  const generator = new CodeGenerator(browserName, launchOptions, contextOptions, output, languageGenerator, options.device, options.saveStorage);
   new ScriptController(context, generator);
   await openPage(context, url);
   if (process.env.PWCLI_EXIT_FOR_TEST)

--- a/src/codegen/codeGenerator.ts
+++ b/src/codegen/codeGenerator.ts
@@ -40,14 +40,14 @@ export class CodeGenerator {
   private _output: CodeGeneratorOutput;
   private _footerText: string;
 
-  constructor(browserName: string, launchOptions: playwright.LaunchOptions, contextOptions: playwright.BrowserContextOptions, output: CodeGeneratorOutput, languageGenerator: LanguageGenerator, deviceName: string | undefined) {
+  constructor(browserName: string, launchOptions: playwright.LaunchOptions, contextOptions: playwright.BrowserContextOptions, output: CodeGeneratorOutput, languageGenerator: LanguageGenerator, deviceName: string | undefined, saveStorage: string | undefined) {
     this._output = output;
     this._languageGenerator = languageGenerator;
 
     launchOptions = { headless: false, ...launchOptions };
     const header = this._languageGenerator.generateHeader(browserName, launchOptions, contextOptions, deviceName);
     this._output.printLn(header);
-    this._footerText = '\n' + this._languageGenerator.generateFooter();
+    this._footerText = '\n' + this._languageGenerator.generateFooter(saveStorage);
     this._output.printLn(this._footerText);
   }
 

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -153,8 +153,9 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
     return formatter.format();
   }
 
-  generateFooter(): string {
-    return `// ---------------------`;
+  generateFooter(saveStorage: string | undefined): string {
+    const storageStateLine = saveStorage ? `\nawait context.StorageStateAsync(path: "${saveStorage}")` : '';
+    return `// ---------------------${storageStateLine}`;
   }
 }
 

--- a/src/codegen/languages/index.ts
+++ b/src/codegen/languages/index.ts
@@ -21,7 +21,7 @@ export type HighlighterType = 'javascript' | 'csharp' | 'python';
 export interface LanguageGenerator {
   generateHeader(browserName: string, launchOptions: playwright.LaunchOptions, contextOptions: playwright.BrowserContextOptions, deviceName?: string): string;
   generateAction(actionInContext: ActionInContext, performingAction: boolean): string;
-  generateFooter(): string;
+  generateFooter(saveStorage: string | undefined): string;
   highligherType(): HighlighterType;
 }
 

--- a/src/codegen/languages/javascript.ts
+++ b/src/codegen/languages/javascript.ts
@@ -155,8 +155,9 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
     return formatter.format();
   }
 
-  generateFooter(): string {
-    return `  // ---------------------
+  generateFooter(saveStorage: string | undefined): string {
+    const storageStateLine = saveStorage ? `\n  await context.storageState({ path: '${saveStorage}' })` : '';
+    return `  // ---------------------${storageStateLine}
   await context.close();
   await browser.close();
 })();`;

--- a/src/codegen/languages/python.ts
+++ b/src/codegen/languages/python.ts
@@ -166,9 +166,10 @@ def run(playwright) {
     return formatter.format();
   }
 
-  generateFooter(): string {
+  generateFooter(saveStorage: string | undefined): string {
     if (this._isAsync) {
-      return `    # ---------------------
+      const storageStateLine = saveStorage ? `\n    await context.storageState(path="${saveStorage}")` : '';
+      return `    # ---------------------${storageStateLine}
     await context.close()
     await browser.close()
 
@@ -177,7 +178,8 @@ async def main():
         await run(playwright)
 asyncio.run(main())`;
     } else {
-      return `    # ---------------------
+      const storageStateLine = saveStorage ? `\n    context.storageState(path="${saveStorage}")` : '';
+      return `    # ---------------------${storageStateLine}
     context.close()
     browser.close()
 

--- a/src/codegen/outputs.ts
+++ b/src/codegen/outputs.ts
@@ -85,6 +85,7 @@ export class TerminalOutput implements CodeGeneratorOutput {
     highlightedCode = highlightedCode.replace(/<span class="hljs-subst">/g, '\x1b[38;5;242m');
     highlightedCode = highlightedCode.replace(/<span class="hljs-function">/g, '');
     highlightedCode = highlightedCode.replace(/<span class="hljs-params">/g, '');
+    highlightedCode = highlightedCode.replace(/<span class="hljs-attr">/g, '');
     highlightedCode = highlightedCode.replace(/<\/span>/g, '\x1b[0m');
     highlightedCode = highlightedCode.replace(/&#x27;/g, "'");
     highlightedCode = highlightedCode.replace(/&quot;/g, '"');

--- a/test/codegen-js.spec.ts
+++ b/test/codegen-js.spec.ts
@@ -107,3 +107,26 @@ it('should save the codegen output to a file if specified', async ({ runCLI, tes
   await browser.close();
 })();`);
 });
+
+it('should print load/save storageState', async ({ runCLI, testInfo }) => {
+  const loadFileName = testInfo.outputPath('load.json');
+  const saveFileName = testInfo.outputPath('save.json');
+  await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
+  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, 'codegen', emptyHTML]);
+  const expectedResult = `const { chromium, devices } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({
+    headless: false
+  });
+  const context = await browser.newContext({
+    storageState: '${loadFileName}'
+  });
+
+  // ---------------------
+  await context.storageState({ path: '${saveFileName}' });
+  await context.close();
+  await browser.close();
+})();`;
+  await cli.waitFor(expectedResult);
+});

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -47,7 +47,7 @@ fixtures.contextWrapper.init(async ({ browser }, runTest) => {
   const outputBuffer = new WritableBuffer();
   const output = new TerminalOutput(outputBuffer as any as Writable, 'javascript');
   const languageGenerator = new JavaScriptLanguageGenerator();
-  const generator = new CodeGenerator('chromium', {}, {}, output, languageGenerator, undefined);
+  const generator = new CodeGenerator('chromium', {}, {}, output, languageGenerator, undefined, undefined);
   new ScriptController(context, generator);
   await runTest({ context, output: outputBuffer });
   await context.close();
@@ -205,9 +205,9 @@ fixtures.runCLI.init(async ({  }, runTest) => {
 class CLIMock {
   private process: ChildProcessWithoutNullStreams
   private data: string;
-  private waitForText: string
+  private waitForText: string;
   private waitForCallback: () => void;
-  exited: Promise<number>
+  exited: Promise<void>;
 
   constructor(args: string[]) {
     this.data = '';
@@ -225,10 +225,9 @@ class CLIMock {
       if (this.waitForCallback && this.data.includes(this.waitForText))
         this.waitForCallback();
     });
-    this.exited = new Promise(r => this.process.on('exit', () => {
+    this.exited = new Promise<void>(r => this.process.on('exit', () => {
       if (this.waitForCallback)
         this.waitForCallback();
-
       return r();
     }));
   }


### PR DESCRIPTION
User can save the storage, and then load the storage in the next script.

```sh
npx playwright-cli --save-storage=storage.json open www.needs-login.com
# Log in and close the browser.

# Now codegen from the logged-in state.
npx playwright-cli --load-storage=storage.json codegen www.needs-login.com
```