### PR TITLE
feat(trace viewer): generate video tiles lazily

### DIFF
--- a/src/traceViewer/videoTileGenerator.ts
+++ b/src/traceViewer/videoTileGenerator.ts
@@ -18,12 +18,39 @@ import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as util from 'util';
+import { TraceModel, videoById, VideoMetaInfo } from './traceModel';
 import { PageVideoTraceEvent } from './traceTypes';
 
+const fsReadFileAsync = util.promisify(fs.readFile.bind(fs));
 const fsWriteFileAsync = util.promisify(fs.writeFile.bind(fs));
 
 export class VideoTileGenerator {
-  async render(events: PageVideoTraceEvent[], videoDir: string) {
+  private _traceModel: TraceModel;
+
+  constructor(traceModel: TraceModel) {
+    this._traceModel = traceModel;
+  }
+
+  tilePath(urlPath: string) {
+    const index = urlPath.lastIndexOf('/');
+    const tile = urlPath.substring(index + 1);
+    const videoId = urlPath.substring(0, index);
+    const { context, page } = videoById(this._traceModel, videoId);
+    const videoFilePath = path.join(path.dirname(context.filePath), page.video!.video.fileName);
+    return videoFilePath + '-' + tile;
+  }
+
+  async render(videoId: string): Promise<VideoMetaInfo | undefined> {
+    const { context, page } = videoById(this._traceModel, videoId);
+    const video = page.video!.video;
+    const videoFilePath = path.join(path.dirname(context.filePath), video.fileName);
+    const metaInfoFilePath = videoFilePath + '-metainfo.txt';
+    try {
+      const metaInfo = await fsReadFileAsync(metaInfoFilePath, 'utf8');
+      return metaInfo ? JSON.parse(metaInfo) : undefined;
+    } catch (e) {
+    }
+
     let ffmpegName = '';
     if (process.platform === 'win32') {
       if (process.arch === 'ia32')
@@ -36,15 +63,36 @@ export class VideoTileGenerator {
     if (process.platform === 'linux')
       ffmpegName = 'ffmpeg-linux';
     const ffmpeg = path.join(path.dirname(require.resolve('playwright')), 'third_party', 'ffmpeg', ffmpegName);
-    for (const event of events) {
-      const fileName = path.join(videoDir, event.fileName);
-      if (fs.existsSync(fileName + '-metainfo.txt'))
-        continue;
-      console.log('Generating frames for ' + fileName);
-      // Force output frame rate to 25 fps as otherwise it would produce one image per timebase unit
-      // which is currently 1 / (25 * 1000).
-      const result = spawnSync(ffmpeg, ['-i', fileName, '-r', '25', `${fileName}-%03d.png`]);
-      await fsWriteFileAsync(fileName + '-metainfo.txt', result.stderr);
-    }
+
+    console.log('Generating frames for ' + videoFilePath);
+    // Force output frame rate to 25 fps as otherwise it would produce one image per timebase unit
+    // which is currently 1 / (25 * 1000).
+    const result = spawnSync(ffmpeg, ['-i', videoFilePath, '-r', '25', `${videoFilePath}-%03d.png`]);
+    const metaInfo = parseMetaInfo(result.stderr.toString(), video);
+    await fsWriteFileAsync(metaInfoFilePath, metaInfo ? JSON.stringify(metaInfo) : '');
+    return metaInfo;
   }
+}
+
+function parseMetaInfo(text: string, video: PageVideoTraceEvent): VideoMetaInfo | undefined {
+  const lines = text.split('\n');
+  let framesLine = lines.find(l => l.startsWith('frame='));
+  if (!framesLine)
+    return;
+  framesLine = framesLine.substring(framesLine.lastIndexOf('frame='));
+  const framesMatch = framesLine.match(/frame=\s+(\d+)/);
+  const outputLineIndex = lines.findIndex(l => l.trim().startsWith('Output #0'));
+  const streamLine = lines.slice(outputLineIndex).find(l => l.trim().startsWith('Stream #0:0'))!;
+  const fpsMatch = streamLine.match(/, (\d+) fps,/);
+  const resolutionMatch = streamLine.match(/, (\d+)x(\d+)\D/);
+  const durationMatch = lines.find(l => l.trim().startsWith('Duration'))!.match(/Duration: (\d+):(\d\d):(\d\d.\d\d)/);
+  const duration = (((parseInt(durationMatch![1], 10) * 60) + parseInt(durationMatch![2], 10)) * 60 + parseFloat(durationMatch![3])) * 1000;
+  return {
+    frames: parseInt(framesMatch![1], 10),
+    width: parseInt(resolutionMatch![1], 10),
+    height: parseInt(resolutionMatch![2], 10),
+    fps: parseInt(fpsMatch![1], 10),
+    startTime: (video as any).timestamp,
+    endTime: (video as any).timestamp + duration
+  };
 }

--- a/src/traceViewer/web/index.tsx
+++ b/src/traceViewer/web/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TraceModel } from '../traceModel';
+import { TraceModel, VideoMetaInfo } from '../traceModel';
 import './common.css';
 import './third_party/vscode/codicon.css';
 import { Workbench } from './ui/workbench';
@@ -25,6 +25,7 @@ import { ActionTraceEvent } from '../traceTypes';
 declare global {
   interface Window {
     getTraceModel(): Promise<TraceModel>;
+    getVideoMetaInfo(videoId: string): Promise<VideoMetaInfo | undefined>;
     readFile(filePath: string): Promise<string>;
     renderSnapshot(action: ActionTraceEvent): void;
   }


### PR DESCRIPTION
We generate meta info lazily on the backend. Also small improvements:
- do not resize film strip while loading to avoid jumping;
- do not launch two browsers accidentally;
- support relative video file names.