### PR TITLE
Fix typo in link to references/tracing.md

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -177,5 +177,5 @@ playwright-cli tracing-stop
 * **Session management** [references/session-management.md](references/session-management.md)
 * **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
 * **Test generation** [references/test-generation.md](references/test-generation.md)
-* **Tracing** [references/tracing.md](references/tracin.md`)
+* **Tracing** [references/tracing.md](references/tracing.md)
 * **Video recording** [references/video-recording.md](references/video-recording.md)


### PR DESCRIPTION
This is a small PR to fix a small typo in the links at the end of the SKILL.md file.