### PR TITLE
Fix flag description for Browser Session Management

### DIFF
--- a/skills/playwright-cli/references/session-management.md
+++ b/skills/playwright-cli/references/session-management.md
@@ -4,7 +4,7 @@ Run multiple isolated browser sessions concurrently with state persistence.
 
 ## Named Browser Sessions
 
-Use `-b` flag to isolate browser contexts:
+Use `-s` flag to isolate browser contexts:
 
 ```bash
 # Browser 1: Authentication flow


### PR DESCRIPTION
This pull request updates the documentation for managing named browser sessions in Playwright CLI. The main change is clarifying the correct flag to use for isolating browser contexts.

Documentation update:

* Updated the session management documentation in `session-management.md` to indicate that the `-s` flag (instead of `-b`) should be used to isolate browser contexts.