### PR TITLE
feat: Add selectable skill installation for Copilot and Claude Code

### DIFF
--- a/.claude/skills/roll/SKILL.md
+++ b/.claude/skills/roll/SKILL.md
@@ -1,4 +1,0 @@
-# How to roll skills
-
-- Read skill file at node_modules/playwright/lib/skill/SKILL.md
-- Update README.md with the new relevant information from skill.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,27 @@ playwright-cli --help
 
 ### Installing skills
 
-Claude Code, GitHub Copilot and others will use the locally installed skills.
+When you run the install command, you'll be prompted to choose where to install the skills:
 
 ```bash
 playwright-cli install --skills
+```
+
+You can select:
+- **Claude Code** (`~/.claude/skills`) - for Claude Code editor
+- **GitHub Copilot** (`~/.copilot/skills`) - for GitHub Copilot CLI
+- **Both** - install to both locations simultaneously
+
+The installer will guide you through an interactive prompt:
+
+```
+🎯 Select installation targets for Playwright CLI skills:
+
+  1) Claude Code (~/.claude/skills)
+  2) GitHub Copilot (~/.copilot/skills)
+  3) Both
+
+Enter your choice (1, 2, or 3):
 ```
 
 ### Skills-less operation

--- a/playwright-cli.js
+++ b/playwright-cli.js
@@ -15,9 +15,22 @@
  * limitations under the License.
  */
 
-const { program } = require('playwright/lib/mcp/terminal/program');
-const packageLocation = require.resolve('./package.json');
-program(packageLocation).catch(e => {
-  console.error(e.message);
-  process.exit(1);
-});
+const { handleInstallSkills } = require('./scripts/install-skills');
+
+// Check if this is an "install --skills" command
+const args = process.argv.slice(2);
+const isInstallSkills = args.includes('install') && args.includes('--skills');
+
+if (isInstallSkills) {
+  handleInstallSkills().catch(e => {
+    console.error(e.message);
+    process.exit(1);
+  });
+} else {
+  const { program } = require('playwright/lib/mcp/terminal/program');
+  const packageLocation = require.resolve('./package.json');
+  program(packageLocation).catch(e => {
+    console.error(e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/install-skills.js
+++ b/scripts/install-skills.js
@@ -1,0 +1,108 @@
+const { execSync } = require('child_process');
+const fs = require('fs/promises');
+const path = require('path');
+const readline = require('readline');
+
+const rootDir = path.resolve(__dirname, '..');
+const homedir = require('os').homedir();
+
+function run(command, options = {}) {
+  execSync(command, { stdio: 'inherit', cwd: rootDir, ...options });
+}
+
+async function promptTargets() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  console.log('\n🎯 Select installation targets for Playwright CLI skills:\n');
+  console.log('  1) Claude Code (~/.claude/skills)');
+  console.log('  2) GitHub Copilot (~/.copilot/skills)');
+  console.log('  3) Both\n');
+
+  return new Promise((resolve) => {
+    rl.question('Enter your choice (1, 2, or 3): ', (answer) => {
+      rl.close();
+      
+      const choice = answer.trim();
+      switch (choice) {
+        case '1':
+          resolve(['claude']);
+          break;
+        case '2':
+          resolve(['copilot']);
+          break;
+        case '3':
+          resolve(['claude', 'copilot']);
+          break;
+        default:
+          console.log('\nInvalid choice. Installing to both targets as default.');
+          resolve(['claude', 'copilot']);
+      }
+    });
+  });
+}
+
+async function copySkills(sourceDir, targetName) {
+  const targetDir = targetName === 'claude' ? '.claude' : '.copilot';
+  const targetPath = path.join(homedir, targetDir, 'skills', 'playwright-cli');
+  
+  console.log(`\n📦 Installing skills to ~/${targetDir}/skills/playwright-cli...`);
+  
+  try {
+    await fs.access(sourceDir);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.rm(targetPath, { recursive: true, force: true });
+    await fs.cp(sourceDir, targetPath, { recursive: true });
+    console.log(`✓ Skills installed successfully!`);
+  } catch (err) {
+    console.warn(`⚠ Warning: Could not install to ${targetPath}:`, err.message);
+    throw err;
+  }
+}
+
+async function handleInstallSkills(options = {}) {
+  console.log('🚀 Playwright CLI Skill Installer\n');
+  
+  // Get user's target selection
+  let targets;
+  if (options.targets) {
+    targets = options.targets;
+  } else {
+    targets = await promptTargets();
+  }
+  
+  // Run the original install command to generate skills in local .claude directory
+  console.log('\n📥 Generating skills...');
+  const { program } = require('playwright/lib/mcp/terminal/program');
+  const packageLocation = require.resolve(path.join(rootDir, 'package.json'));
+  
+  // Call the upstream install with --skills (creates in cwd/.claude/skills)
+  await program(packageLocation);
+  
+  // Source is the local .claude/skills/playwright-cli created by upstream
+  const localSkillsPath = path.join(process.cwd(), '.claude', 'skills', 'playwright-cli');
+  
+  // Copy to selected user home directory targets
+  for (const target of targets) {
+    const targetDir = target === 'claude' ? '.claude' : '.copilot';
+    const targetPath = path.join(homedir, targetDir, 'skills', 'playwright-cli');
+    
+    console.log(`\n📦 Installing skills to ~/${targetDir}/skills/playwright-cli...`);
+    
+    try {
+      await fs.access(localSkillsPath);
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.rm(targetPath, { recursive: true, force: true });
+      await fs.cp(localSkillsPath, targetPath, { recursive: true });
+      console.log(`✓ Skills installed successfully!`);
+    } catch (err) {
+      console.warn(`⚠ Warning: Could not install to ${targetPath}:`, err.message);
+    }
+  }
+  
+  console.log('\n✨ Installation complete!\n');
+}
+
+module.exports = { handleInstallSkills };

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -17,9 +17,10 @@ async function main() {
   const { version } = require(path.join(rootDir, 'node_modules', '@playwright', 'cli', 'package.json'));
   console.log(`Installed @playwright/cli version: ${version}`);
 
-  // 2. Run playwright-cli install-skills
-  console.log('\n=== Running playwright-cli install --skills ===\n');
-  run('npx playwright-cli install --skills');
+  // 2. Install skills to both Claude Code and GitHub Copilot
+  console.log('\n=== Installing skills to Claude Code and GitHub Copilot ===\n');
+  const { handleInstallSkills } = require(path.join(rootDir, 'scripts', 'install-skills'));
+  await handleInstallSkills({ targets: ['claude', 'copilot'] });
 
   // 3. Move generated skills into the existing skills folder
   console.log('\n=== Updating skills folder ===\n');


### PR DESCRIPTION
- Add interactive prompt to choose installation targets (Claude Code, GitHub Copilot, or both)
- Create new scripts/install-skills.js module to handle multi-target installation
- Update playwright-cli.js to intercept 'install --skills' command
- Update scripts/update.js to install to both targets by default
- Update README.md with installation instructions and examples

Users can now select where to install skills when running:
  playwright-cli install --skills