### PR TITLE
fix: update deprecated Playwright API usage in running-code docs

### DIFF
--- a/skills/playwright-cli/references/running-code.md
+++ b/skills/playwright-cli/references/running-code.md
@@ -87,7 +87,7 @@ playwright-cli run-code "async page => {
 
 # Wait for specific element
 playwright-cli run-code "async page => {
-  await page.waitForSelector('.loading', { state: 'hidden' });
+  await page.locator('.loading').waitFor({ state: 'hidden' });
 }"
 
 # Wait for function to return true
@@ -97,7 +97,7 @@ playwright-cli run-code "async page => {
 
 # Wait with timeout
 playwright-cli run-code "async page => {
-  await page.waitForSelector('.result', { timeout: 10000 });
+  await page.locator('.result').waitFor({ timeout: 10000 });
 }"
 ```
 
@@ -122,10 +122,9 @@ playwright-cli run-code "async page => {
 ```bash
 # Handle file download
 playwright-cli run-code "async page => {
-  const [download] = await Promise.all([
-    page.waitForEvent('download'),
-    page.click('a.download-link')
-  ]);
+  const downloadPromise = page.waitForEvent('download');
+  await page.locator('a.download-link').click();
+  const download = await downloadPromise;
   await download.saveAs('./downloaded-file.pdf');
   return download.suggestedFilename();
 }"
@@ -197,7 +196,7 @@ playwright-cli run-code "async page => {
 # Try-catch in run-code
 playwright-cli run-code "async page => {
   try {
-    await page.click('.maybe-missing', { timeout: 1000 });
+    await page.locator('.maybe-missing').click({ timeout: 1000 });
     return 'clicked';
   } catch (e) {
     return 'element not found';
@@ -211,9 +210,9 @@ playwright-cli run-code "async page => {
 # Login and save state
 playwright-cli run-code "async page => {
   await page.goto('https://example.com/login');
-  await page.fill('input[name=email]', 'user@example.com');
-  await page.fill('input[name=password]', 'secret');
-  await page.click('button[type=submit]');
+  await page.locator('input[name=email]').fill('user@example.com');
+  await page.locator('input[name=password]').fill('secret');
+  await page.locator('button[type=submit]').click();
   await page.waitForURL('**/dashboard');
   await page.context().storageState({ path: 'auth.json' });
   return 'Login successful';


### PR DESCRIPTION
## Summary
- Replace deprecated `page.click()`, `page.fill()`, `page.waitForSelector()` with modern `page.locator()` equivalents in `running-code.md`
- Fix `Promise.all` race condition anti-pattern in file download example

## Test plan
- [ ] Verify all code examples in `running-code.md` use current Playwright APIs
- [ ] Confirm no deprecated methods remain (`page.click`, `page.fill`, `page.waitForSelector`)