### PR TITLE
Change playwright-cli commands to use @playwright/cli for `npx` commands

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -219,8 +219,8 @@ playwright-cli kill-all
 In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx playwright-cli` to run the commands. For example:
 
 ```bash
-npx playwright-cli open https://example.com
-npx playwright-cli click e1
+npx @playwright/cli open https://example.com
+npx @playwright/cli click e1
 ```
 
 ## Example: Form submission


### PR DESCRIPTION
Updated commands in SKILL.md to use @playwright/cli. 

Avoids this warning:

```
npm warn deprecated playwright-cli@0.262.0: This package is deprecated, use @playwright/cli instead.
```