### PR TITLE
docs: add --headed flag to SKILL.md open parameters

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -170,6 +170,9 @@ playwright-cli open --persistent
 # Use persistent profile with custom directory
 playwright-cli open --profile=/path/to/profile
 
+# Open with visible browser window (headless by default)
+playwright-cli open --headed
+
 # Start with config file
 playwright-cli open --config=my-config.json
 


### PR DESCRIPTION
The `--headed` flag was missing from the skill documentation. Document that `playwright-cli open` runs headless by default and show how to pass `--headed` to get a visible browser window.