### PR TITLE
feat: add pi.skills to package.json for agent skill discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"
+  },
+  "pi": {
+    "skills": ["./skills/"]
   }
 }


### PR DESCRIPTION
Closes #304

Adds a `pi.skills` field to `package.json` so the `playwright-cli` skill is auto-discovered when installed via the [pi coding agent](https://shittycodingagent.ai). Related to #294 and #299.