### PR TITLE
docs: add show command to SKILL.md DevTools section

### DIFF
--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -153,6 +153,7 @@ playwright-cli tracing-start
 playwright-cli tracing-stop
 playwright-cli video-start
 playwright-cli video-stop video.webm
+playwright-cli show
 ```
 
 ## Open parameters


### PR DESCRIPTION
The `show` command is documented in the README under the Monitoring section but is missing from the SKILL.md DevTools commands list. This adds it so agents using the skill file are aware of the monitoring dashboard.