### PR TITLE
fix: install-browser now actually installs browsers

### DIFF
--- a/playwright-cli.js
+++ b/playwright-cli.js
@@ -15,4 +15,44 @@
  * limitations under the License.
  */
 
-require('playwright/lib/cli/client/program');
+const args = process.argv.slice(2);
+const command = args.find(a => !a.startsWith('-'));
+
+if (command === 'install-browser') {
+  const minimist = require('minimist');
+  const parsed = minimist(args, { string: ['_', 'browser'], boolean: ['help', 'h'] });
+
+  if (parsed.help || parsed.h) {
+    console.log(
+      'playwright-cli install-browser [browser]\n\n' +
+      'Install browser\n\n' +
+      'Arguments:\n' +
+      '  [browser]                   browser to install: chromium, firefox, webkit, chrome, msedge\n' +
+      'Options:\n' +
+      '  --browser                   browser to install (alternative to positional argument)'
+    );
+    process.exit(0);
+  }
+
+  const browserName = parsed._[1] || parsed.browser;
+  if (!browserName) {
+    console.error('Browser name is required. Usage: playwright-cli install-browser <browser>\nPossible values: chromium, firefox, webkit, chrome, msedge');
+    process.exit(1);
+  }
+
+  import('playwright-core/lib/server/registry/index').then(({ registry }) => {
+    const executable = registry.findExecutable(browserName);
+    if (!executable) {
+      console.error(`Unknown browser: "${browserName}". Possible values: chromium, firefox, webkit, chrome, msedge`);
+      process.exit(1);
+    }
+    registry.install([executable]).then(() => {
+      console.log(`Browser "${browserName}" installed successfully.`);
+    }).catch(e => {
+      console.error(e.message);
+      process.exit(1);
+    });
+  });
+} else {
+  require('playwright/lib/cli/client/program');
+}

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -59,6 +59,30 @@ async function runCli(...args: string[]): Promise<CliResult> {
   });
 }
 
+test('install-browser installs successfully', async ({}) => {
+  const result = await runCli('install-browser', 'chromium');
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('installed successfully');
+});
+
+test('install-browser with --browser flag', async ({}) => {
+  const result = await runCli('install-browser', '--browser=chromium');
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('installed successfully');
+});
+
+test('install-browser fails for unknown browser', async ({}) => {
+  const result = await runCli('install-browser', 'bogus');
+  expect(result.exitCode).toBe(1);
+  expect(result.error).toContain('Unknown browser');
+});
+
+test('install-browser fails without browser name', async ({}) => {
+  const result = await runCli('install-browser');
+  expect(result.exitCode).toBe(1);
+  expect(result.error).toContain('Browser name is required');
+});
+
 test('open data URL', async ({}) => {
   expect(await runCli('open', 'data:text/html,hello', '--persistent')).toEqual(expect.objectContaining({
     output: expect.stringContaining('hello'),


### PR DESCRIPTION
## What's broken

`playwright-cli install-browser webkit` tells you to run `playwright-cli install-browser webkit`. That's the whole bug — the install command points at itself.

The bundled `program.js` has no case for `install-browser` in its switch statement. It falls through to the default path, which tries to connect to a running browser session and forward the command to the daemon. The daemon checks for the browser, doesn't find the right version, and tells you to run the command you just ran.

## The fix

Intercept `install-browser` in `playwright-cli.js` before it ever reaches the bundled Playwright code. Use `playwright-core`'s registry directly to find and install the exact browser version matching the CLI's bundled Playwright.

Both syntaxes work:
```
playwright-cli install-browser webkit
playwright-cli install-browser --browser=webkit
```

Error messages are useful:
```
$ playwright-cli install-browser
Browser name is required. Usage: playwright-cli install-browser <browser>
Possible values: chromium, firefox, webkit, chrome, msedge

$ playwright-cli install-browser bogus
Unknown browser: "bogus". Possible values: chromium, firefox, webkit, chrome, msedge
```

## Why fix it here and not in the Playwright monorepo

The real source lives in the Playwright monorepo. The proper long-term fix is adding an `install-browser` case to the switch in `program.js` there. That's a reasonable follow-up.

But this fix is self-contained, lives entirely in the one file this repo controls (`playwright-cli.js`), and solves the problem now. No waiting on upstream. If you'd rather I submit the fix to the Playwright monorepo instead, happy to do that.

## Tests

Four new tests covering the happy path (positional arg, `--browser` flag) and error cases (unknown browser, missing name). All pass alongside the existing test.

## Test plan

- [x] `playwright-cli install-browser webkit` — installs successfully
- [x] `playwright-cli install-browser --browser=webkit` — installs successfully
- [x] `playwright-cli install-browser bogus` — clear error, exit 1
- [x] `playwright-cli install-browser` (no arg) — clear error, exit 1
- [x] `playwright-cli --help` — still works
- [x] `playwright-cli open` / other commands — unaffected
- [x] `npm test` — all 5 tests pass