### PR TITLE
fix: use correct npm package name @playwright/cli in npx references

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ playwright-cli kill-all                 # forcefully kill all browser processes
 
 ### Local installation
 
-If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+If global `playwright-cli` command is not available, try a local version via `npx @playwright/cli`:
 
 ```bash
 npx --no-install playwright-cli --version
 ```
 
-When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+When local version is available, use `npx @playwright/cli` in all commands. Otherwise, install `playwright-cli` as a global command:
 
 ```bash
 npm install -g @playwright/cli@latest

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -241,13 +241,13 @@ playwright-cli kill-all
 
 ## Installation
 
-If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+If global `playwright-cli` command is not available, try a local version via `npx @playwright/cli`:
 
 ```bash
 npx --no-install playwright-cli --version
 ```
 
-When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+When local version is available, use `npx @playwright/cli` in all commands. Otherwise, install `playwright-cli` as a global command:
 
 ```bash
 npm install -g @playwright/cli@latest


### PR DESCRIPTION
## Summary

The Installation / Local installation sections in both `README.md` and `skills/playwright-cli/SKILL.md` reference `npx playwright-cli` in the prose. However, the correct npm package name is `@playwright/cli` (scoped). The old `playwright-cli` package on npm is **deprecated**:

```
$ npm view playwright-cli
playwright-cli@0.262.0 | Apache-2.0
DEPRECATED - This package is deprecated, use @playwright/cli instead.
```

Using `npx playwright-cli` (without `--no-install`) will download and run the deprecated package instead of the current one. This is particularly problematic for AI coding agents that use `npx -y playwright-cli` as a non-interactive fallback.

## Changes

- `README.md`: Replace `npx playwright-cli` with `npx @playwright/cli` in prose (2 lines)
- `skills/playwright-cli/SKILL.md`: Same replacement (2 lines)
- The `npx --no-install playwright-cli --version` check line is left unchanged since `--no-install` only resolves locally installed binaries

Fixes #327