### PR TITLE
chore: mark v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "minimist": "^1.2.5",
-        "playwright": "^1.60.0-alpha-1775061447000"
+        "playwright": "1.60.0-alpha-1775061447000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.60.0-alpha-1775061447000",
+        "@playwright/test": "1.60.0-alpha-1775061447000",
         "@types/node": "^25.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Roll Playwright to 1.60.0-alpha-1775061447000
- Bump package version to 0.1.4