### PR TITLE
fix(deps): remove unused minimist dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "minimist": "^1.2.5",
         "playwright": "1.60.0-alpha-1775951570000"
       },
       "bin": {
@@ -61,15 +60,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/playwright": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "minimist": "^1.2.5",
     "playwright": "1.60.0-alpha-1775951570000"
   },
   "bin": {


### PR DESCRIPTION
## Summary
- Remove unused `minimist` dependency that has a known prototype pollution vulnerability (GHSA-xvch-5gv4-984h)

Fixes https://github.com/microsoft/playwright-cli/issues/359