### PR TITLE
chore: mark v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0-alpha-1775951570000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **Remote debugging mode against your local Chrome** ([#358](https://github.com/microsoft/playwright-cli/issues/358)) — you can now drive the Chrome you already have open, with its existing logins, instead of a sandboxed copy. `playwright-cli attach --cdp=chrome` (also `msedge`, `chrome-canary`, etc.) resolves the channel and connects via `chrome://inspect/#remote-debugging`. Supports Chrome / Chrome Beta / Dev / Canary and Edge / Edge Beta / Dev / Canary on Linux, macOS, and Windows. ([microsoft/playwright#40177](https://github.com/microsoft/playwright/pull/40177))
- **Heavy CPU/memory and orphaned Chrome processes** ([#360](https://github.com/microsoft/playwright-cli/issues/360)) — no more manually killing leftover Chrome processes after long CLI/agent sessions. ([microsoft/playwright#40190](https://github.com/microsoft/playwright/pull/40190))

## Fixes

- `fix(mcp): no tombstones on the server registry level` — defaults `browserToken` to `'chrome'` when none is specified (no more `undefined` in userDataDir paths); simplifies stale-entry cleanup in the server registry; passes `force` to session stop during `delete-data`. ([#40179](https://github.com/microsoft/playwright/pull/40179))

## Upgrading

```bash
npm install -g @playwright/cli@0.1.8
```
