### PR TITLE
chore: mark v0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0-alpha-2026-04-14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **`show --annotate`** — provide agent with visual and structural feedback while developing or testing. ([microsoft/playwright#40262](https://github.com/microsoft/playwright/pull/40262), [microsoft/playwright#40238](https://github.com/microsoft/playwright/pull/40238))

    <center>
      <img width="584" height="486" alt="Screenshot from 2026-04-24 17-58-53" src="https://github.com/user-attachments/assets/cb00fe36-ffd8-4c47-ba98-7e707e483bdb" />
    </center>

- **`drop` command for files and clipboard-like data** — drop files or typed data (`text/plain`, `text/html`, etc.) onto an element from outside the page. Useful for file-upload widgets and drag-from-desktop scenarios where `upload` doesn't fit. ([microsoft/playwright#40367](https://github.com/microsoft/playwright/pull/40367), [microsoft/playwright#40283](https://github.com/microsoft/playwright/pull/40283))
- **`highlight` command for visual confirmation** — show a persistent highlight overlay on an element (with optional custom CSS via `--style`), and hide one or all overlays with `--hide`. Lets coding agents visually confirm what they're about to act on. ([microsoft/playwright#40213](https://github.com/microsoft/playwright/pull/40213), [microsoft/playwright#40215](https://github.com/microsoft/playwright/pull/40215), [microsoft/playwright#40219](https://github.com/microsoft/playwright/pull/40219))
- **`generate-locator` command** — produce a stable Playwright locator expression for an element ref. Pair with `--raw` to feed locators straight into test assertions. ([microsoft/playwright#40313](https://github.com/microsoft/playwright/pull/40313))
- **`--json` global flag** — wrap every reply as structured JSON for machine parsing. ([microsoft/playwright#40284](https://github.com/microsoft/playwright/pull/40284))

  ```bash
  > playwright-cli eval --json "document.body.childNodes.length"
  {
    "result": "4"
  }
  ```

- **`snapshot --boxes`** — include each element's bounding box as `[box=x,y,width,height]` in aria snapshots, making it easy to drive coordinate-based tools off of a snapshot. ([microsoft/playwright#40389](https://github.com/microsoft/playwright/pull/40389))
  
    ```yaml
  - paragraph [ref=e35] [box=86,381,700,99]:
      - text: One API to drive Chromium, Firefox, and WebKit — in your tests, your scripts...
      - link "TypeScript" [ref=e36] [cursor=pointer] [box=535,417,98,27]:
        - /url: https://playwright.dev/docs/intro
      - text: ","
      - link "Python" [ref=e37] [cursor=pointer] [box=644,417,66,27]:
        - /url: https://playwright.dev/python/docs/intro
      - text: ","
      - link ".NET" [ref=e38] [cursor=pointer] [box=721,417,42,27]:
        - /url: https://playwright.dev/dotnet/docs/intro
      - text: ", and"
      - link "Java" [ref=e39] [cursor=pointer] [box=127,450,38,27]:
        - /url: https://playwright.dev/java/docs/intro
    ```

- **Discover attachable system browsers with `list --all`** — surfaces Chrome/Edge instances running with remote debugging so `attach --cdp=<channel>` has something to connect to. ([microsoft/playwright#40253](https://github.com/microsoft/playwright/pull/40253), [microsoft/playwright#40342](https://github.com/microsoft/playwright/pull/40342))
- **`detach` command and channel-named attach sessions** — attach sessions now use the channel name (e.g. `chrome`, `msedge`) and can be cleanly detached without closing the underlying browser. ([microsoft/playwright#40408](https://github.com/microsoft/playwright/pull/40408))
- **Skill discoverable from `--help`** — `playwright-cli --help` now prints the path to the installed agent skill, so coding agents can find it without being told. ([microsoft/playwright#40274](https://github.com/microsoft/playwright/pull/40274))
- **`run-code` accepts a file** — `playwright-cli run-code --filename=./script.js` runs a Playwright snippet from disk instead of the command line. ([microsoft/playwright-cli#337](https://github.com/microsoft/playwright-cli/issues/337))

## Behavior changes

- `attach` now requires an explicit target; bare `attach` is no longer allowed. ([microsoft/playwright@f7555ef](https://github.com/microsoft/playwright/commit/f7555ef26))
- The "Playwright MCP Bridge" extension has been renamed to "Playwright Extension", and the CLI now warns when the extension is missing from the target profile. ([microsoft/playwright#40259](https://github.com/microsoft/playwright/pull/40259), [microsoft/playwright#40406](https://github.com/microsoft/playwright/pull/40406))
- CLI option names have been tidied up to be friendlier for Claude Code and other agents. ([microsoft/playwright#40369](https://github.com/microsoft/playwright/pull/40369))

## Fixes

- `fix(cli): exit daemon when extension connection fails` — no more orphaned daemons when the browser extension can't connect. ([microsoft/playwright#40328](https://github.com/microsoft/playwright/pull/40328))
- `fix(cli): prefix bare filenames with ./ in printed links` — output file links now open reliably in terminals and editors. ([microsoft/playwright#40311](https://github.com/microsoft/playwright/pull/40311))
- `fix(cli): show "(no browsers)" when list is empty without --all` — clearer empty-state output from `list`. ([microsoft/playwright#40277](https://github.com/microsoft/playwright/pull/40277))
- `fix(mcp): disable CDP timeout for extension connection` — long-running extension attaches no longer time out. ([microsoft/playwright#40265](https://github.com/microsoft/playwright/pull/40265))
- `fix(mcp): support page close via extension in protocol v2` — closing tabs through the extension works again. ([microsoft/playwright#40249](https://github.com/microsoft/playwright/pull/40249))
- `fix(mcp): throw clear error for tab creation in extension protocol v1` — replaces a cryptic failure with a readable message. ([microsoft/playwright#40261](https://github.com/microsoft/playwright/pull/40261))
- `fix(mcp): ensure --proxy-server overrides config-file proxy` — explicit CLI proxy now wins over the config value. ([microsoft/playwright#40212](https://github.com/microsoft/playwright/pull/40212))
- `fix(server): close browsers when PlaywrightServer shuts down` — cleaner shutdown, no lingering browser processes. ([microsoft/playwright#40294](https://github.com/microsoft/playwright/pull/40294))

## Upgrading

```bash
npm install -g @playwright/cli@latest
```