### PR TITLE
chore: roll Playwright to 1.60.0-alpha-1777077614000

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ playwright-cli highlight --hide         # hide all page highlights
 
 ```bash
 playwright-cli open --browser=chrome    # use specific browser
-playwright-cli attach --extension       # connect via browser extension
+playwright-cli attach --extension=chrome # connect via Playwright Extension
 playwright-cli attach --cdp=chrome      # attach to running Chrome/Edge by channel
 playwright-cli attach --cdp=<url>       # attach via CDP endpoint
+playwright-cli detach                   # detach an attached session, leaves the external browser running
 playwright-cli open --persistent        # use persistent profile
 playwright-cli open --profile=<path>    # use custom profile directory
 playwright-cli open --config=file.json  # use config file

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-2026-04-24"
+        "playwright": "1.60.0-alpha-1777077614000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.60.0-alpha-2026-04-24",
+        "@playwright/test": "1.60.0-alpha-1777077614000",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -23,13 +23,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-2026-04-24",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-2026-04-24.tgz",
-      "integrity": "sha512-wabVVb3guSb1/D7ECR6R3oyGA805ZRxPJ4rKp7Ljpnv7Kr4OhP4hqb/ovwTG8tI+Ux2PmjGXModLH0+zkfoBDA==",
+      "version": "1.60.0-alpha-1777077614000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1777077614000.tgz",
+      "integrity": "sha512-zBcSZTwgke+UR/pUj/hjhX1npshDd8Rc5faF/VB9TOooocPBe1QxaMRbacTXKBvz69dwx0idRW2ZIYWagQlO5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-2026-04-24"
+        "playwright": "1.60.0-alpha-1777077614000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-2026-04-24",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-2026-04-24.tgz",
-      "integrity": "sha512-9N912tAUJ1vyHpxsmJHP+Taexi4ZMDluPx0H4uON+PYgCSOIKOtdkkDAZo1L8wsRw3ACyCWa2VZ1Ja9VsuXSXQ==",
+      "version": "1.60.0-alpha-1777077614000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777077614000.tgz",
+      "integrity": "sha512-Uykk/hbDlIaw4aZZZHMni6I0Y9eBtC7+UzH3QwTh9pJEEuYVq14y7F3bcHNCNCI0sLkY0oEiWK+2VeOtB6vUDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-2026-04-24"
+        "playwright-core": "1.60.0-alpha-1777077614000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-2026-04-24",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-2026-04-24.tgz",
-      "integrity": "sha512-sp2lxbvT8MLbjicQl39Op1db8W/IYHwtWfvpikjplcV9hKQaYUbqDoha0tISHjZAQDSPJqTaREmv7uKKgA0uUg==",
+      "version": "1.60.0-alpha-1777077614000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777077614000.tgz",
+      "integrity": "sha512-cAEm1N5jh0WMr9/EG4nPDbR326paHfMFa2FyHibhIfDGTswbKv8sYvaa9S0UXkgITdv4h6lQfcsD9Dl73lFZsg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0-alpha-2026-04-24",
+    "@playwright/test": "1.60.0-alpha-1777077614000",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-2026-04-24"
+    "playwright": "1.60.0-alpha-1777077614000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -209,8 +209,8 @@ playwright-cli open --persistent
 # Use persistent profile with custom directory
 playwright-cli open --profile=/path/to/profile
 
-# Connect to browser via extension
-playwright-cli attach --extension
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
 
 # Connect to a running Chrome or Edge by channel name
 playwright-cli attach --cdp=chrome
@@ -224,6 +224,8 @@ playwright-cli open --config=my-config.json
 
 # Close the browser
 playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
 # Delete user data for the default session
 playwright-cli delete-data
 ```

--- a/skills/playwright-cli/references/session-management.md
+++ b/skills/playwright-cli/references/session-management.md
@@ -129,6 +129,8 @@ playwright-cli attach --cdp=msedge-dev
 
 Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
 
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
 ### Attach via CDP endpoint
 
 Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
@@ -144,6 +146,20 @@ Connect to a browser with the Playwright extension installed:
 ```bash
 playwright-cli attach --extension
 ```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
 
 ## Default Browser Session
 


### PR DESCRIPTION
## Summary
- Roll `playwright` and `@playwright/test` to `1.60.0-alpha-1777077614000` (2026-04-25 UTC).
- Skills regenerated; README updated for `attach --extension=<channel>` and the new `detach` command.