### PR TITLE
docs: document artifact output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ Playwright CLI is headless by default. If you'd like to see the browser, pass `-
 playwright-cli open https://playwright.dev --headed
 ```
 
+## Avoiding workspace artifacts
+
+By default, Playwright CLI writes generated artifacts relative to the workspace. Set
+`PLAYWRIGHT_MCP_OUTPUT_DIR` to keep automatically named files in a dedicated directory:
+
+```bash
+export PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli
+playwright-cli open http://localhost:3000
+playwright-cli snapshot
+playwright-cli screenshot
+playwright-cli pdf
+playwright-cli state-save
+```
+
+This affects default output paths for automatic snapshots after commands, `snapshot`, `screenshot`,
+`pdf`, and `state-save` when those commands use their default filenames. If you explicitly pass a
+relative path, such as `--filename=page.png`, Playwright CLI currently saves exactly to that path in
+the current directory.
+
 ## Sessions
 
 Playwright CLI keeps the browser profile in memory by default. Your cookies and storage state

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -23,6 +23,24 @@ playwright-cli screenshot
 playwright-cli close
 ```
 
+## Avoiding workspace artifacts
+
+Before running browser automation in a workspace, prefer setting
+`PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli` so default snapshots, screenshots, PDFs, and storage
+state files stay in one artifact directory.
+
+```bash
+export PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli
+playwright-cli open http://localhost:3000
+playwright-cli snapshot
+playwright-cli screenshot
+playwright-cli pdf
+playwright-cli state-save
+```
+
+This affects automatically named output files, including snapshots captured after commands. Explicit
+relative paths, such as `--filename=page.png`, are currently saved relative to the current directory.
+
 ## Commands
 
 ### Core


### PR DESCRIPTION
## Summary

- Document using `PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli` to keep automatically named artifacts out of the workspace root.
- Add the same guidance to the installed `playwright-cli` skill so coding agents set the output directory before browser automation.
- Note that explicit relative paths such as `--filename=page.png` are still written relative to the current directory.

## Follow-up

Opened #382 to discuss whether explicit relative `--filename` paths should keep the current behavior or get clearer output-directory handling.

## Testing

- `git diff --check`
- Manually verified in temporary directories that default `snapshot`, `screenshot`, `pdf`, and `state-save` artifacts are written under `.playwright-cli/` when `PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli` is set.
- Manually verified that `playwright-cli screenshot --filename=page.png` still writes `./page.png` with `PLAYWRIGHT_MCP_OUTPUT_DIR=.playwright-cli` set.