### PR TITLE
Quality: Uses internal Playwright module path for CLI bootstrap

### DIFF
--- a/playwright-cli.js
+++ b/playwright-cli.js
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-const { program } = require('playwright-core/lib/tools/cli-client/program');
-const packageJson = require('./package.json');
-
-program({ embedderVersion: packageJson.version });
+try {
+  require('playwright-core/cli');
+} catch (error) {
+  if (error && error.code === 'MODULE_NOT_FOUND' && error.message.includes('playwright-core/cli')) {
+    console.error('Failed to load Playwright CLI from playwright-core. Please ensure a compatible playwright-core version is installed.');
+    process.exit(1);
+  }
+  throw error;
+}

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -11,9 +11,9 @@ function run(command, options = {}) {
 }
 
 async function main() {
-  // 2. Run playwright-cli install-skills
-  console.log('\n=== Running playwright-cli install --skills ===\n');
-  run('node playwright-cli.js install --skills');
+  // 2. Run playwright-core CLI install-skills
+  console.log('\n=== Running playwright-core install --skills ===\n');
+  run('npx playwright-core install --skills');
 
   // 3. Move generated skills into the existing skills folder
   console.log('\n=== Updating skills folder ===\n');


### PR DESCRIPTION
## Problem

`playwright-cli.js` requires `playwright-core/lib/tools/cli-client/program`, which is an internal, non-public path. Internal module layouts can change between releases and break this package without a clear migration path.

**Severity**: `high`
**File**: `playwright-cli.js`

## Solution

Depend on a documented/public Playwright CLI entrypoint (or expose one in `playwright-core`) instead of importing from `lib/...` internals. If unavoidable, pin compatible versions tightly and add a startup guard with a clear error message when the import path changes.

## Changes

- `playwright-cli.js` (modified)
- `scripts/update.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
