### PR TITLE
chore: roll Playwright to 1.60.0-alpha-1777575331000

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ playwright-cli video-start [filename]   # start video recording
 playwright-cli video-chapter <title>    # add a chapter marker to the video
 playwright-cli video-stop               # stop video recording
 playwright-cli show                     # open the visual dashboard
-playwright-cli annotate                 # launch dashboard for UI review / design feedback
+playwright-cli show --annotate          # launch dashboard with annotation prompt
 playwright-cli generate-locator <ref>   # generate a playwright locator for an element
 playwright-cli highlight <ref>          # show a persistent highlight overlay
 playwright-cli highlight <ref> --style= # highlight with a custom CSS style

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1777566615000"
+        "playwright": "1.60.0-alpha-1777575331000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.60.0-alpha-1777566615000",
+        "@playwright/test": "1.60.0-alpha-1777575331000",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -23,13 +23,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-1777566615000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1777566615000.tgz",
-      "integrity": "sha512-EBGZI/5WjEhIvXsa+6q7XrYDif1YyL9bmp7t6IKN4Aa/OWedI7Pw9a6Calk5Uqx6SNCco8qTXHpBI95+5+mvww==",
+      "version": "1.60.0-alpha-1777575331000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1777575331000.tgz",
+      "integrity": "sha512-g3/CQYL/GBGu723pK5R6tzIJ01VWrOCxaAGSZ+V0jBUo9cAfxg1RrtYxX7HKEJdFvMewUtToE1/HOGR/iA3jXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1777566615000"
+        "playwright": "1.60.0-alpha-1777575331000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1777566615000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777566615000.tgz",
-      "integrity": "sha512-ENFFNacDBbDBLUtn4FsdZowN9CxsO22/xlgvhgiyzW6FM/PoWM5GSwNl2c0LMvcFYkmmPbB6uGHFL9T2U9ufVQ==",
+      "version": "1.60.0-alpha-1777575331000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777575331000.tgz",
+      "integrity": "sha512-TYI1/8r4dZvIGx7GKHeZB988av806iVPsYlFIqZEYibzgHzcFvYpAGhsT2EfkPlAJr3oj1VB2v+qOX63N4g98w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1777566615000"
+        "playwright-core": "1.60.0-alpha-1777575331000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1777566615000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777566615000.tgz",
-      "integrity": "sha512-68GgyVu5NAgQzU8YdbYS/PZCStmiJoV3kclnAIb9Yau+wj23O1pLyMprw2MgenE0lIBU5aFvkHdv/LB8oMd1Xg==",
+      "version": "1.60.0-alpha-1777575331000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777575331000.tgz",
+      "integrity": "sha512-kdE6dgKSqblFZegsB2A50urVCTHddjTs7i48W8mD5huaO9SZh6Ch4xG2qe9spw6ILGjGLp2VMxXk8uYY91e1JQ==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0-alpha-1777566615000",
+    "@playwright/test": "1.60.0-alpha-1777575331000",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1777566615000"
+    "playwright": "1.60.0-alpha-1777575331000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -163,8 +163,8 @@ playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 
-# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
-playwright-cli annotate
+# launch the dashboard with annotation prompt to ask the user for input
+playwright-cli show --annotate
 
 # generate a Playwright locator for an element from its ref or selector
 playwright-cli generate-locator e5 --raw
@@ -367,11 +367,11 @@ playwright-cli close
 
 ## Example: Interactive session
 
-Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+Ask the user to annotate the UI. User can provide contextual tasks or ask contextual questions using annotations:
 
 ```bash
 playwright-cli open https://example.com
-playwright-cli annotate
+playwright-cli show --annotate
 ```
 
 ## Specific tasks

--- a/skills/playwright-cli/references/spec-driven-testing.md
+++ b/skills/playwright-cli/references/spec-driven-testing.md
@@ -88,7 +88,7 @@ playwright-cli resume                   # resume so that seed test runs fully
 playwright-cli snapshot                 # inventory of interactive elements
 playwright-cli click e5                 # follow a flow
 playwright-cli eval "location.href"     # read URL / state
-playwright-cli annotate                  # ask the user to point at something
+playwright-cli show --annotate          # ask the user to point at something
 ```
 
 Map out:
@@ -262,7 +262,7 @@ The test is paused at the start. Step forward or run to until just before the fa
 playwright-cli snapshot                # did the element change / move / rename?
 playwright-cli console                 # app-side errors?
 playwright-cli network                 # failed request? wrong payload?
-playwright-cli annotate                 # ask the user to point somewhere
+playwright-cli show --annotate         # ask the user to point somewhere
 ```
 
 Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.


### PR DESCRIPTION
## Summary
- Bumps `playwright` and `@playwright/test` to `1.60.0-alpha-1777575331000`
- Regenerates skills; reverts `annotate` back to `show --annotate` (upstream revert)
- Updates README to match
