### PR TITLE
chore: mark v0.1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 20
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '20'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0-alpha-1777669338000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.11
- Downgrade CI Node.js from 22 to 20