### PR TITLE
fix(deps): declare playwright-core as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1777669338000"
+        "playwright": "1.60.0-alpha-1777669338000",
+        "playwright-core": "1.60.0-alpha-1777669338000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1777669338000"
+    "playwright": "1.60.0-alpha-1777669338000",
+    "playwright-core": "1.60.0-alpha-1777669338000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"


### PR DESCRIPTION
## Summary
- `playwright-cli.js` does `require('playwright-core/lib/tools/cli-client/program')` but `package.json` only declares `playwright`. Under pnpm's default `isolated` `node-linker`, the require walk fails on every fresh install (`Cannot find module 'playwright-core/lib/tools/cli-client/program'`).
- Add `playwright-core` to `dependencies`, pinned to the same `1.60.0-alpha-1777669338000` as `playwright`. The existing transitive resolution stays the same, npm-hoisted layouts are unaffected, and isolated-layout installs (pnpm, pnp) now resolve correctly.
- Same shape as `@playwright/test`'s `cli.js`, which declares `playwright` as a direct dep because it does `require('playwright/lib/program')`. `playwright-core` already lists `./lib/tools/cli-client/program` in its `exports` field; declaring `playwright-core` directly here keeps `package.json` in sync with the require.

## Test plan
- Removed `nodeLinker: hoisted` from the global pnpm config so the default `isolated` layout was active for the comparison.
- `pnpm install -g @playwright/cli@latest` (current npm `latest`) crashes as above.
- `npm pack` of this branch then `pnpm install -g ./playwright-cli-0.1.11.tgz` produces a working install: `playwright-cli --version` returns `0.1.11`, `playwright-cli open https://example.com` loads the page and captures a snapshot.
- Regression check: same tarball under `npm install` resolves cleanly (no change to hoisted-layout behavior).
- `npm test` passes (`tests/integration.spec.ts: open data URL`, 1 passed).

Fixes https://github.com/microsoft/playwright-cli/issues/396