### PR TITLE
chore: roll Playwright to 1.60.0-alpha-1778101408000

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ playwright-cli video-start [filename]   # start video recording
 playwright-cli video-chapter <title>    # add a chapter marker to the video
 playwright-cli video-stop               # stop video recording
 playwright-cli show                     # open the visual dashboard
-playwright-cli show --annotate          # launch dashboard with annotation prompt
+playwright-cli show --annotate          # launch dashboard for UI review / design feedback
 playwright-cli generate-locator <ref>   # generate a playwright locator for an element
 playwright-cli highlight <ref>          # show a persistent highlight overlay
 playwright-cli highlight <ref> --style= # highlight with a custom CSS style

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1777669338000",
-        "playwright-core": "1.60.0-alpha-1777669338000"
+        "playwright": "1.60.0-alpha-1778101408000",
+        "playwright-core": "1.60.0-alpha-1778101408000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.60.0-alpha-1777669338000",
+        "@playwright/test": "1.60.0-alpha-1778101408000",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-1777669338000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1777669338000.tgz",
-      "integrity": "sha512-bAZ9tvx+w2RJs25zDpDcMOpEqiDpaRDWQgNRnnJGIdUTab6rEtir/R4LR/OPtmFHLMh4QiJ3brCr3PEAu/KQ9A==",
+      "version": "1.60.0-alpha-1778101408000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1778101408000.tgz",
+      "integrity": "sha512-PHq+eONL5DyYpzr7v10CYompnGsohn9cS74x1L22Kj5TdEqnSJA8VFKs1yWKLjt+fZup8Ezmi8ALYoNaW7TWgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1777669338000"
+        "playwright": "1.60.0-alpha-1778101408000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1777669338000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777669338000.tgz",
-      "integrity": "sha512-r5G2ZvpIJZHj53GKmUfoQiXHix5bjeObqysV4flfmFNykTjebI9bwdRBuW37pOQP25yjbArkxlsnT5APaWT8zg==",
+      "version": "1.60.0-alpha-1778101408000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1778101408000.tgz",
+      "integrity": "sha512-GbACwe8/0+2vKk/bKrjPrcWt0LbJXU2wt3Vu4c+gzAeg75PhQE4DXVh8Zs7JeD8x0c8chNFE7tlvGkoZJG3qIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1777669338000"
+        "playwright-core": "1.60.0-alpha-1778101408000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1777669338000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777669338000.tgz",
-      "integrity": "sha512-CbBF+YtjGGK2mWKdH6iiSNIB9v9Sq8owcUrTy1cw6FgMZavspM6ZSpidQQgQXz/1scQFrM110jrtJqTYwnjbeA==",
+      "version": "1.60.0-alpha-1778101408000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1778101408000.tgz",
+      "integrity": "sha512-qZj4IYvTOBbM63N+nR24IidgS5pPuManZfafRf15ugQNma//w5ikpZFWIH/SjP89jTSH8s5ai7jIwyhBYgSrng==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0-alpha-1777669338000",
+    "@playwright/test": "1.60.0-alpha-1778101408000",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1777669338000",
-    "playwright-core": "1.60.0-alpha-1777669338000"
+    "playwright": "1.60.0-alpha-1778101408000",
+    "playwright-core": "1.60.0-alpha-1778101408000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -163,7 +163,7 @@ playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 
-# launch the dashboard with annotation prompt to ask the user for input
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
 playwright-cli show --annotate
 
 # generate a Playwright locator for an element from its ref or selector
@@ -367,7 +367,7 @@ playwright-cli close
 
 ## Example: Interactive session
 
-Ask the user to annotate the UI. User can provide contextual tasks or ask contextual questions using annotations:
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
 
 ```bash
 playwright-cli open https://example.com


### PR DESCRIPTION
## Summary
- Bumps `playwright`, `playwright-core` and `@playwright/test` to `1.60.0-alpha-1778101408000`
- Regenerates skills; updates `--annotate` description to emphasize UI review / design feedback
- Updates README to match