### PR TITLE
chore: roll Playwright to 1.61.0-alpha-1778188671000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1778101408000",
-        "playwright-core": "1.60.0-alpha-1778101408000"
+        "playwright": "1.61.0-alpha-1778188671000",
+        "playwright-core": "1.61.0-alpha-1778188671000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.60.0-alpha-1778101408000",
+        "@playwright/test": "1.61.0-alpha-1778188671000",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-1778101408000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1778101408000.tgz",
-      "integrity": "sha512-PHq+eONL5DyYpzr7v10CYompnGsohn9cS74x1L22Kj5TdEqnSJA8VFKs1yWKLjt+fZup8Ezmi8ALYoNaW7TWgQ==",
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-nyL+Zt6eCThBEBQmOaVfGlCEqT/YX1t5qdfbnqy4zrhPcmwAfrkBu6VHYVGqe90UmMduItgSlbfPt9egMA9R+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1778101408000"
+        "playwright": "1.61.0-alpha-1778188671000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1778101408000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1778101408000.tgz",
-      "integrity": "sha512-GbACwe8/0+2vKk/bKrjPrcWt0LbJXU2wt3Vu4c+gzAeg75PhQE4DXVh8Zs7JeD8x0c8chNFE7tlvGkoZJG3qIQ==",
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1778101408000"
+        "playwright-core": "1.61.0-alpha-1778188671000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1778101408000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1778101408000.tgz",
-      "integrity": "sha512-qZj4IYvTOBbM63N+nR24IidgS5pPuManZfafRf15ugQNma//w5ikpZFWIH/SjP89jTSH8s5ai7jIwyhBYgSrng==",
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0-alpha-1778101408000",
+    "@playwright/test": "1.61.0-alpha-1778188671000",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1778101408000",
-    "playwright-core": "1.60.0-alpha-1778101408000"
+    "playwright": "1.61.0-alpha-1778188671000",
+    "playwright-core": "1.61.0-alpha-1778188671000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"


### PR DESCRIPTION
## Summary
- Bump `playwright`, `playwright-core`, and `@playwright/test` to `1.61.0-alpha-1778188671000`.