### PR TITLE
chore: mark v0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.0-alpha-1778188671000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Fixes

- `fix(mcp): forward browser-level CDP commands in extension mode` — `cookie-list`, `state-save`, and other browser-scoped commands now work when attached via the Chrome extension. ([microsoft/playwright#40706](https://github.com/microsoft/playwright/pull/40706))