### PR TITLE
chore: mark v0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.0-alpha-1781023400000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **Annotate actions in recorded videos** — new `video-show-actions` / `video-hide-actions` commands draw a callout naming each action and highlighting its target in the recording. ([microsoft/playwright#40914](https://github.com/microsoft/playwright/pull/40914))
- **`exposeNetwork` and other connect options for remote browsers** ([microsoft/playwright#40478](https://github.com/microsoft/playwright/issues/40478)) — `remoteEndpoint` now accepts a full `ConnectOptions` object, so settings like `exposeNetwork` and headers apply to remote connections. ([microsoft/playwright#40964](https://github.com/microsoft/playwright/pull/40964))
- **Bounded output size** — `--output-max-size` caps captured output and evicts to disk after the response, keeping large sessions manageable. ([microsoft/playwright#41031](https://github.com/microsoft/playwright/pull/41031))

## Fixes

- `fix(cli): support attaching to a Playwright browser server endpoint` ([microsoft/playwright#41154](https://github.com/microsoft/playwright/issues/41154)) — `playwright-cli attach --endpoint=<ws-url>` connects to a running browser server instead of erroring out. ([microsoft/playwright#41203](https://github.com/microsoft/playwright/pull/41203))
- `fix(mcp): support moz-firefox BiDi channels via --browser` — connect to Firefox over BiDi using `--browser`. ([microsoft/playwright#41126](https://github.com/microsoft/playwright/pull/41126))
- `fix(mcp): keep remoteHeaders working for remote browser endpoint` — custom headers are sent again when connecting to a remote endpoint. ([microsoft/playwright#41156](https://github.com/microsoft/playwright/pull/41156), [#40828](https://github.com/microsoft/playwright/pull/40828))
- `fix(cli): persist traces when CLI attaches to existing CDP browser` — traces are now saved when attaching over CDP. ([microsoft/playwright#40810](https://github.com/microsoft/playwright/pull/40810))
- `fix(cli): accept single --modifiers value for click and dblclick` — `--modifiers=Shift` works without requiring a list. ([microsoft/playwright#40784](https://github.com/microsoft/playwright/pull/40784))
- `fix(cli): trim overlong session names to fit unix socket path limit` — long session names no longer break the daemon socket. ([microsoft/playwright#40898](https://github.com/microsoft/playwright/pull/40898))
- `fix(cli): do not pass PLAYWRIGHT_CLI_SESSION as daemon --endpoint` — fixes spurious endpoint resolution from the session env var. ([microsoft/playwright#41019](https://github.com/microsoft/playwright/pull/41019))
- `fix(mcp): report missing ffmpeg distinctly from missing browser` — clearer error when video recording fails due to a missing ffmpeg. ([microsoft/playwright#40867](https://github.com/microsoft/playwright/pull/40867))
- `fix(mcp): report invalid tool arguments` — invalid arguments now produce a readable error instead of failing silently. ([microsoft/playwright#40979](https://github.com/microsoft/playwright/pull/40979))
- `fix(mcp): use writable cache dir for MCP user data, not browsers path` — avoids permission errors on read-only browser installs. ([microsoft/playwright#40961](https://github.com/microsoft/playwright/pull/40961))
- `fix(mcp): use waitUntil commit for navigate back/forward` — back/forward navigation resolves more reliably. ([microsoft/playwright#41153](https://github.com/microsoft/playwright/pull/41153))
- `fix(mcp): tear down dashboard server on cli show --kill` — `cli show --kill` fully stops the dashboard. ([microsoft/playwright#40968](https://github.com/microsoft/playwright/pull/40968))
- `fix(tracing): mkdir tracesDir before live .stacks writes` — fixes a crash when the traces directory does not yet exist. ([microsoft/playwright#40730](https://github.com/microsoft/playwright/pull/40730))
- `docs(cli): document & URL escaping on Windows` — guidance on escaping `&` in URLs on cmd.exe and PowerShell. ([microsoft/playwright#40742](https://github.com/microsoft/playwright/pull/40742))

## Upgrading

```bash
npm install -g @playwright/cli@0.1.14
```