### PR TITLE
chore: roll Playwright to 1.62.0-alpha-2026-06-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ playwright-cli mousewheel <dx> <dy>     # scroll mouse wheel
 ```bash
 playwright-cli screenshot [ref]         # screenshot of the current page or element
 playwright-cli screenshot --filename=f  # save screenshot with specific filename
+playwright-cli screenshot --hires       # capture at full device pixel ratio
 playwright-cli pdf                      # save page as pdf
 playwright-cli pdf --filename=page.pdf  # save pdf with specific filename
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0-alpha-1781023400000",
-        "playwright-core": "1.61.0-alpha-1781023400000"
+        "playwright": "1.62.0-alpha-2026-06-29",
+        "playwright-core": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.61.0-alpha-1781023400000",
+        "@playwright/test": "1.62.0-alpha-2026-06-29",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-EYeA59CsSOtiQgKTBAyl321SwaWzLYD4wU9GDAt8kFpYCco3sClPZBPdKXdUwlrNqOFAbseUYtiFudxFs/h02w==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-g9foBBuWf7IoALxyck3GJjjl/dsUewmxXz8a3JNgKgqgHFOZou9DZA7isi0hLU9Lz+75LeBSxN92E+aI7KAbUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0-alpha-1781023400000"
+        "playwright": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright": "cli.js"
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-ugaMuh6rAOqmbaxrM7+XQSs7M6yPXykq5gVugJPClHcJ4Cqxmky5rDHhrCt4wmaILUeMdI7kPBCx3zMx2Qu+bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0-alpha-1781023400000"
+        "playwright-core": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright": "cli.js"
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-/13EvW8l9Bmvt9nKHey+OcvZ8nob2FM8BCKBsUNwbXgmT4Hc0XX2b6mOErU0RBYNedOCa9q15USI7SY9K17v4w==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.61.0-alpha-1781023400000",
+    "@playwright/test": "1.62.0-alpha-2026-06-29",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.61.0-alpha-1781023400000",
-    "playwright-core": "1.61.0-alpha-1781023400000"
+    "playwright": "1.62.0-alpha-2026-06-29",
+    "playwright-core": "1.62.0-alpha-2026-06-29"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -93,6 +93,7 @@ playwright-cli mousewheel 0 100
 playwright-cli screenshot
 playwright-cli screenshot e5
 playwright-cli screenshot --filename=page.png
+playwright-cli screenshot --hires
 playwright-cli pdf --filename=page.pdf
 ```
 


### PR DESCRIPTION
## Summary
- Roll Playwright to `1.62.0-alpha-2026-06-29`
- Regenerated CLI skill (adds `screenshot --hires`) and documented the flag in the README