### PR TITLE
chore: mark v0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.0-alpha-2026-06-29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **High resolution screenshots** ([#376](https://github.com/microsoft/playwright-cli/issues/376)) — `playwright-cli screenshot --hires` captures at the device's full pixel ratio instead of downscaling to CSS pixels. ([microsoft/playwright#41465](https://github.com/microsoft/playwright/pull/41465))
- **Secrets no longer leak into console logs** ([#41509](https://github.com/microsoft/playwright/issues/41509)) — configured secret values are now redacted in captured console log artifacts. ([microsoft/playwright#41515](https://github.com/microsoft/playwright/pull/41515))
- **Configurable heartbeat ping timeout** — the keep-alive ping timeout can now be tuned for slow or long-running sessions. ([microsoft/playwright#41391](https://github.com/microsoft/playwright/pull/41391))

## Heads up

- **The CLI now checks for updates** — on startup it notifies you when a newer `@playwright/cli` is available on npm. ([#426](https://github.com/microsoft/playwright-cli/pull/426))
- **The CLI now warns when your installed skill is out of date** — if the bundled Playwright skill is newer than the one installed in your workspace, you'll be prompted to reinstall it. Re-run `playwright-cli install --skills` to update. ([#427](https://github.com/microsoft/playwright-cli/pull/427))

## Fixes

- `fix(mcp): pass action timeout to browser_wait_for waitFor calls` — `wait_for` now honors the configured action timeout instead of waiting indefinitely. ([microsoft/playwright#41270](https://github.com/microsoft/playwright/pull/41270))
- `fix(mcp): wait for next pause or context closure in browser_resume` — resuming a paused session settles reliably. ([microsoft/playwright#41293](https://github.com/microsoft/playwright/pull/41293))
- `fix(mcp): assign caps as array for legacy --vision flag` — the legacy `--vision` flag works again. ([microsoft/playwright#41253](https://github.com/microsoft/playwright/pull/41253))
- `fix(mcp): never include data: URL payloads in snapshot or network output` — large `data:` URLs no longer flood snapshot and network output. ([microsoft/playwright#41450](https://github.com/microsoft/playwright/pull/41450))
- `fix(mcp): list a failed network request only once` — failed requests are no longer duplicated in network output. ([microsoft/playwright#41481](https://github.com/microsoft/playwright/pull/41481))
- `fix(mcp): check tracing state before stopping in browser_stop_tracing` — stopping tracing when it is not running no longer errors. ([microsoft/playwright#41040](https://github.com/microsoft/playwright/pull/41040))
- `fix(mcp): add missing .catch() on sessionLog write queue` — a failed session-log write no longer crashes the session. ([microsoft/playwright#41234](https://github.com/microsoft/playwright/pull/41234))
- `fix(tracing): add missing error handlers to createWriteStream pipes` — trace write errors are handled instead of crashing. ([microsoft/playwright#41227](https://github.com/microsoft/playwright/pull/41227))
- `fix(tracing): copy WebSocket message files before zipping` — WebSocket frames are no longer dropped from saved traces. ([microsoft/playwright#41382](https://github.com/microsoft/playwright/pull/41382))
- `fix(tracing): stop recording websocket frames outside of chunks` — avoids corrupt WebSocket data in traces. ([microsoft/playwright#41398](https://github.com/microsoft/playwright/pull/41398))
- `chore: PLAYWRIGHT_TRACING_NO_WEBSOCKET_FRAMES and PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES` — new env vars to disable recording WebSocket frames in traces and HARs. ([microsoft/playwright#41295](https://github.com/microsoft/playwright/pull/41295))

## Upgrading

```bash
npm install -g @playwright/cli@0.1.15
```