### PR TITLE
chore: mark v0.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.0-alpha-2026-07-08",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **Search a large snapshot instead of capturing the whole thing** — the new `find` command searches the page snapshot for text or a regexp and returns just the matching nodes with surrounding context (like `grep -C`), keeping big pages out of the model context. ([microsoft/playwright#41605](https://github.com/microsoft/playwright/pull/41605), [microsoft/playwright#41654](https://github.com/microsoft/playwright/pull/41654))
- **Mobile emulation** — `open --mobile` emulates a generic mobile device (Pixel for Chromium, iPhone for WebKit) and `--device="iPhone 15"` targets a specific one; mobile pages are usually lighter, so snapshots are smaller and cheaper. ([microsoft/playwright#41657](https://github.com/microsoft/playwright/pull/41657))
- **Leaner snapshots** — AI snapshots are distilled to be less verbose, cutting token cost on every command that returns page state. ([microsoft/playwright#41604](https://github.com/microsoft/playwright/pull/41604))
- **Local invocation via `npx playwright cli`** — the CLI is now exposed as `playwright cli` (and `playwright mcp`), so a locally installed Playwright can drive it without a separate global install. ([microsoft/playwright#41577](https://github.com/microsoft/playwright/pull/41577))

## Fixes

- **`goto` no longer crashes the browser session on privileged pages** ([#433](https://github.com/microsoft/playwright-cli/issues/433)) — navigating to pages like `chrome://extensions/` used to throw `TypeError: Cannot read properties of undefined (reading 'url')` and take down the session. ([microsoft/playwright#41675](https://github.com/microsoft/playwright/pull/41675))
- `feat(mcp): surface non-2xx navigation status` — navigation now reports the HTTP status instead of silently succeeding on error responses. ([microsoft/playwright#41589](https://github.com/microsoft/playwright/pull/41589))
- `fix(mcp): await init page before screenshot` — screenshots taken right after open no longer race the page init. ([microsoft/playwright#41646](https://github.com/microsoft/playwright/pull/41646))
- `fix(mcp): enable the chromium sandbox for the default browser` — the default Chromium browser now runs sandboxed. ([microsoft/playwright#41652](https://github.com/microsoft/playwright/pull/41652))
- `fix(mcp): preserve directory for additional tab videos` — videos for extra tabs are saved to the configured output directory. ([microsoft/playwright#41680](https://github.com/microsoft/playwright/pull/41680))
- `feat(mcp): always pass noDefaults for CDP connections` — attaching over CDP no longer applies unwanted default context options. ([microsoft/playwright#41676](https://github.com/microsoft/playwright/pull/41676))

