### PR TITLE
chore: roll Playwright to 1.62.0-alpha-1783623505000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-2026-07-08",
-        "playwright-core": "1.62.0-alpha-2026-07-08"
+        "playwright": "1.62.0-alpha-1783623505000",
+        "playwright-core": "1.62.0-alpha-1783623505000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.62.0-alpha-2026-07-08",
+        "@playwright/test": "1.62.0-alpha-1783623505000",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0-alpha-2026-07-08",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-07-08.tgz",
-      "integrity": "sha512-D0qozGfVOuI8x9fD70vK0H5ntL+rNz5oOHRhT+SxMJIKP0OyjA6P95GfLFUeliaCxR1nR3jc4KRZcI2UhRYyXw==",
+      "version": "1.62.0-alpha-1783623505000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1783623505000.tgz",
+      "integrity": "sha512-6aj9UWRXnS2amfs+8BHPRqQNTyiq91MF8Pl0UechaJkW0TZfvLxEjvhBnSrs6Lm3jcLmkkv/QTpW5NyslKZpTw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-2026-07-08"
+        "playwright": "1.62.0-alpha-1783623505000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0-alpha-2026-07-08",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-07-08.tgz",
-      "integrity": "sha512-5vivHdZSnbUW3iutwp2kbr9wjsdFR7OIEUcMvsR5g8Iy/PeYm0uZRwKwTsnZMPr43uFCdW4RQIj0ioszIL31MQ==",
+      "version": "1.62.0-alpha-1783623505000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1783623505000.tgz",
+      "integrity": "sha512-6KV9h4PP3hqu4NaGdxxcijWfYh9LJcFI/R2sP4TTC4I5cFo3oRawN0ETlW5MkE3cQEgKhhoj0KUNz4sfpCT0Tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0-alpha-2026-07-08"
+        "playwright-core": "1.62.0-alpha-1783623505000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0-alpha-2026-07-08",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-07-08.tgz",
-      "integrity": "sha512-1GEx9eELpB6cdtb1MTSeh7K4LP5k9vuaT4HlIsldD/8nvVhf1k2DqBQZHHyAs3oSTfz6MhqVaMEM4VkyjoPsLw==",
+      "version": "1.62.0-alpha-1783623505000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1783623505000.tgz",
+      "integrity": "sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.0-alpha-2026-07-08",
+    "@playwright/test": "1.62.0-alpha-1783623505000",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.62.0-alpha-2026-07-08",
-    "playwright-core": "1.62.0-alpha-2026-07-08"
+    "playwright": "1.62.0-alpha-1783623505000",
+    "playwright-core": "1.62.0-alpha-1783623505000"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"


### PR DESCRIPTION
## Summary
- Roll Playwright to `1.62.0-alpha-1783623505000` (`playwright`, `playwright-core`, `@playwright/test`).
- Picks up the fixes that missed the previous alpha cut (#41675, #41646, #41680, #41676).
- No skill or README changes in this roll.