### PR TITLE
chore: mark v0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.0-alpha-1783623505000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Fixes

- **`goto` no longer crashes the browser session on privileged pages** ([#433](https://github.com/microsoft/playwright-cli/issues/433)) — navigating to pages like `chrome://extensions/` or `chrome://settings/` used to throw `TypeError: Cannot read properties of undefined (reading 'url')` and take down the whole session. ([microsoft/playwright#41675](https://github.com/microsoft/playwright/pull/41675))
- `fix(mcp): await init page before screenshot` — screenshots taken right after open no longer race the page init. ([microsoft/playwright#41646](https://github.com/microsoft/playwright/pull/41646))
- `fix(mcp): preserve directory for additional tab videos` — videos for extra tabs are saved to the configured output directory. ([microsoft/playwright#41680](https://github.com/microsoft/playwright/pull/41680))
- `feat(mcp): always pass noDefaults for CDP connections` — attaching over CDP no longer applies unwanted default context options. ([microsoft/playwright#41676](https://github.com/microsoft/playwright/pull/41676))

## Upgrading

```bash
npm install -g @playwright/cli@0.1.17
```