### PR TITLE
docs(skills): document video-start --size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ playwright-cli run-code <code>          # run playwright code snippet
 playwright-cli run-code --filename=f    # run playwright code from a file
 playwright-cli tracing-start            # start trace recording
 playwright-cli tracing-stop             # stop trace recording
-playwright-cli video-start [filename]   # start video recording
+playwright-cli video-start [filename]   # start video recording (default fits 800x800; use --size=WxH)
 playwright-cli video-chapter <title>    # add a chapter marker to the video
 playwright-cli video-show-actions       # annotate each action with a callout in the video
 playwright-cli video-hide-actions       # stop annotating actions in the video

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -165,7 +165,7 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
-# default size fits within 800x800 — pass --size to match the page viewport
+# default size fits within 800x800 — pass --size for full resolution
 playwright-cli video-start video.webm --size=1280x720
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -165,7 +165,8 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
-playwright-cli video-start video.webm
+# default size fits within 800x800 — pass --size to match the page viewport
+playwright-cli video-start video.webm --size=1280x720
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 

--- a/skills/playwright-cli/references/video-recording.md
+++ b/skills/playwright-cli/references/video-recording.md
@@ -9,7 +9,8 @@ Capture browser automation sessions as video for debugging, documentation, or ve
 playwright-cli open
 
 # Start recording
-playwright-cli video-start demo.webm
+# Default size fits within 800x800 — pass --size to match the page viewport or desired resolution
+playwright-cli video-start demo.webm --size=1280x720
 
 # Add a chapter marker for section transitions
 playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
@@ -29,15 +30,28 @@ playwright-cli video-stop
 
 ## Best Practices
 
-### 1. Use Descriptive Filenames
+### 1. Set an explicit video size
+
+By default, `video-start` records at a size that fits within **800x800**, which is often smaller than the page viewport and can look cropped or low-res. Pass `--size=WIDTHxHEIGHT` to control the output resolution:
+
+```bash
+# Match a common desktop viewport
+playwright-cli video-start demo.webm --size=1280x720
+
+# Match a resized browser window
+playwright-cli resize 1440 900
+playwright-cli video-start demo.webm --size=1440x900
+```
+
+### 2. Use Descriptive Filenames
 
 ```bash
 # Include context in filename
-playwright-cli video-start recordings/login-flow-2024-01-15.webm
-playwright-cli video-start recordings/checkout-test-run-42.webm
+playwright-cli video-start recordings/login-flow-2024-01-15.webm --size=1280x720
+playwright-cli video-start recordings/checkout-test-run-42.webm --size=1280x720
 ```
 
-### 2. Record entire hero scripts.
+### 3. Record entire hero scripts.
 
 When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
 It allows inserting appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
@@ -50,7 +64,8 @@ It allows inserting appropriate pauses between the actions and annotating the vi
 
 ```js
 async page => {
-  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  // Always pass size — default recording fits within 800x800 and will not match the page viewport
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 720 } });
   await page.goto('https://demo.playwright.dev/todomvc');
 
   // Show a chapter card — blurs the page and shows a dialog.

--- a/skills/playwright-cli/references/video-recording.md
+++ b/skills/playwright-cli/references/video-recording.md
@@ -9,7 +9,7 @@ Capture browser automation sessions as video for debugging, documentation, or ve
 playwright-cli open
 
 # Start recording
-# Default size fits within 800x800 — pass --size to match the page viewport or desired resolution
+# Default size fits within 800x800 — pass --size for full resolution
 playwright-cli video-start demo.webm --size=1280x720
 
 # Add a chapter marker for section transitions
@@ -32,13 +32,13 @@ playwright-cli video-stop
 
 ### 1. Set an explicit video size
 
-By default, `video-start` records at a size that fits within **800x800**, which is often smaller than the page viewport and can look cropped or low-res. Pass `--size=WIDTHxHEIGHT` to control the output resolution:
+By default, `video-start` scales the recording so it fits within **800x800** (longer side ≤ 800). That is usually smaller than the page viewport and looks low-res. Pass `--size=WIDTHxHEIGHT` for the output resolution you want:
 
 ```bash
-# Match a common desktop viewport
+# Common desktop resolution
 playwright-cli video-start demo.webm --size=1280x720
 
-# Match a resized browser window
+# Same dimensions as the browser viewport after resize
 playwright-cli resize 1440 900
 playwright-cli video-start demo.webm --size=1440x900
 ```
@@ -64,8 +64,8 @@ It allows inserting appropriate pauses between the actions and annotating the vi
 
 ```js
 async page => {
-  // Always pass size — default recording fits within 800x800 and will not match the page viewport
-  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 720 } });
+  // Always pass size — without it, recording is scaled to fit within 800x800
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
   await page.goto('https://demo.playwright.dev/todomvc');
 
   // Show a chapter card — blurs the page and shows a dialog.


### PR DESCRIPTION
## Summary
- Document that `video-start` defaults to a scaled size that fits within 800x800 (longer side ≤ 800), not full page resolution
- Instruct agents/users to pass `--size=WIDTHxHEIGHT` for the desired output resolution
- Update skill command examples, video-recording reference, and README

## Motivation
`playwright-cli video-start` already supports `--size`, and the CLI help says the default “will fit 800x800”. Agents loading the skill often omit `--size` and get a downscaled recording. This change surfaces the option in the docs agents actually read.

## Accuracy notes
Verified against Playwright core `Screencast._startScreencast`: when `size` is omitted it uses the context viewport (or 800x600 fallback) and scales with `Math.min(1, 800 / max(width, height))`. Help text: `--size` / “fit 800x800”.