### PR TITLE
chore: roll Playwright to 1.63.0-alpha-2026-08-05

### DIFF
--- a/.claude/skills/dev/roll.md
+++ b/.claude/skills/dev/roll.md
@@ -6,8 +6,9 @@
   `npm info playwright@next version`
 
 2. **Update Playwright packages** in `package.json`:
-   - Update `playwright` (dependency) and `@playwright/test` (devDependency) to the target version.
+   - Update `playwright` and `playwright-core` (dependencies) and `@playwright/test` (devDependency) to the target version.
    - Run `npm install` to update `package-lock.json`.
+   - Verify with `npm ls playwright-core` that the root `playwright-core` actually rolled — it is pinned directly in `package.json` and is what `playwright-cli.js` runs; forgetting it leaves the CLI on the old version while tests pass against the new `@playwright/test`.
 
 3. **Run the update script** to sync skills and README:
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-1783623505000",
-        "playwright-core": "1.62.0-alpha-1783623505000"
+        "playwright": "1.63.0-alpha-2026-08-05",
+        "playwright-core": "1.63.0-alpha-2026-08-05"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.62.0-alpha-1783623505000",
+        "@playwright/test": "1.63.0-alpha-2026-08-05",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0-alpha-1783623505000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1783623505000.tgz",
-      "integrity": "sha512-6aj9UWRXnS2amfs+8BHPRqQNTyiq91MF8Pl0UechaJkW0TZfvLxEjvhBnSrs6Lm3jcLmkkv/QTpW5NyslKZpTw==",
+      "version": "1.63.0-alpha-2026-08-05",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0-alpha-2026-08-05.tgz",
+      "integrity": "sha512-Q63UaqUDAAwdrGwYjvlLXsfltkUkmRqqwkZ7SSmY3qDGAH2gUcIHWvHauU5xnWhBrIVHej07sGUbErS3QL39tw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-1783623505000"
+        "playwright": "1.63.0-alpha-2026-08-05"
       },
       "bin": {
         "playwright": "cli.js"
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0-alpha-1783623505000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1783623505000.tgz",
-      "integrity": "sha512-6KV9h4PP3hqu4NaGdxxcijWfYh9LJcFI/R2sP4TTC4I5cFo3oRawN0ETlW5MkE3cQEgKhhoj0KUNz4sfpCT0Tg==",
+      "version": "1.63.0-alpha-2026-08-05",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-05.tgz",
+      "integrity": "sha512-zbGZUK+JYkoDV3cUgfvh2czTBJL34Gmz5gHVI25xiIpvYSR17Q1M7TS8hnwECUe+IkKaeXbKrSyJTyogm2DVWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0-alpha-1783623505000"
+        "playwright-core": "1.63.0-alpha-2026-08-05"
       },
       "bin": {
         "playwright": "cli.js"
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0-alpha-1783623505000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1783623505000.tgz",
-      "integrity": "sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ==",
+      "version": "1.63.0-alpha-2026-08-05",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-05.tgz",
+      "integrity": "sha512-YussvUybTfBtyYbGXWh43f+5kNP03wg98M6mu4DphYET7PSbNVajsdLGjWE1xrsjqOw32i2wFlRP7U5mcOpMZg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.0-alpha-1783623505000",
+    "@playwright/test": "1.63.0-alpha-2026-08-05",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.62.0-alpha-1783623505000",
-    "playwright-core": "1.62.0-alpha-1783623505000"
+    "playwright": "1.63.0-alpha-2026-08-05",
+    "playwright-core": "1.63.0-alpha-2026-08-05"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skillCheck.js
+++ b/skillCheck.js
@@ -20,8 +20,8 @@ const fs = require('fs');
 const path = require('path');
 
 function bundledSkillFile() {
-  const programPath = require.resolve('playwright-core/lib/tools/cli-client/program');
-  return path.join(path.dirname(programPath), 'skill', 'SKILL.md');
+  const corePath = require.resolve('playwright-core/package.json');
+  return path.join(path.dirname(corePath), 'lib', 'tools', 'skills', 'playwright-cli', 'SKILL.md');
 }
 
 function installedSkillTargets() {


### PR DESCRIPTION
Roll Playwright to 1.63.0-alpha-2026-08-05.

- Bump `playwright`, `playwright-core` and `@playwright/test` to 1.63.0-alpha-2026-08-05.
- Adapt `skillCheck.js` to the new bundled skill location (`lib/tools/skills/playwright-cli/SKILL.md`, moved in microsoft/playwright#41887).
- Update the roll instructions to include the `playwright-core` pin.