### PR TITLE
chore: mark v0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/cli",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.63.0-alpha-2026-08-05",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Playwright CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Highlights

- **`install --skills` supports the `-g` flag** ([microsoft/playwright#42087](https://github.com/microsoft/playwright/issues/42087)) — installs the skill into your home directory instead of the current workspace. ([microsoft/playwright#42099](https://github.com/microsoft/playwright/pull/42099))
- **Generated code in Python, Java and C#** ([microsoft/playwright-mcp#1696](https://github.com/microsoft/playwright-mcp/issues/1696)) — code can be generated in Python, Java and C# in addition to JavaScript. ([microsoft/playwright#42106](https://github.com/microsoft/playwright/pull/42106))
- **Configurable post-action settle delay** — tune how long the CLI waits for the page to settle after each action. ([microsoft/playwright#41924](https://github.com/microsoft/playwright/pull/41924))

## Fixes

- `feat(mcp): emit structured snapshot in --json responses` — `--json` no longer wraps formatted text in a string; responses carry a structured page snapshot. ([microsoft/playwright#42076](https://github.com/microsoft/playwright/issues/42076), [microsoft/playwright#42098](https://github.com/microsoft/playwright/pull/42098))
- `feat(mcp): add snapshot.boxes config to include bounding boxes in snapshots` — bounding boxes can now be enabled globally via config rather than per snapshot. ([microsoft/playwright-mcp#1695](https://github.com/microsoft/playwright-mcp/issues/1695), [microsoft/playwright#42102](https://github.com/microsoft/playwright/pull/42102))
- `fix(cli): exit with non-zero code when the tool result is an error` — failed commands no longer exit with status 0, so scripts and agents can detect errors. ([microsoft/playwright#42028](https://github.com/microsoft/playwright/issues/42028), [microsoft/playwright#42042](https://github.com/microsoft/playwright/pull/42042))
- `fix(cli): accept multiple files in upload command` — `upload` no longer rejects a second file although it advertises "one or multiple files". ([microsoft/playwright#42047](https://github.com/microsoft/playwright/issues/42047), [microsoft/playwright#42057](https://github.com/microsoft/playwright/pull/42057))
- `fix(mcp): reconnect to the browser after disconnect` — the relay reconnects after the browser extension disconnects. ([microsoft/playwright#41874](https://github.com/microsoft/playwright/issues/41874), [microsoft/playwright#41966](https://github.com/microsoft/playwright/pull/41966))
- `fix(mcp): launch the Chrome profile that has the extension installed` — `attach` no longer targets a different profile than the one with the extension. ([microsoft/playwright#41916](https://github.com/microsoft/playwright/issues/41916), [microsoft/playwright#41939](https://github.com/microsoft/playwright/pull/41939))
- `fix(mcp): pass noDefaults for extension CDP connections` — extension connections no longer override existing browser defaults. ([microsoft/playwright#42117](https://github.com/microsoft/playwright/issues/42117), [microsoft/playwright#42119](https://github.com/microsoft/playwright/pull/42119))
- `fix(mcp): clear dialog modal state when dialog is closed out of band` — dialogs dismissed by hand in headed mode no longer leave the session stuck in a modal state. ([microsoft/playwright#42032](https://github.com/microsoft/playwright/pull/42032))
- `fix(mcp): report malformed JSON config instead of falling back to INI` — a broken JSON config file now produces a clear error instead of being silently parsed as INI. ([microsoft/playwright#41909](https://github.com/microsoft/playwright/pull/41909))
- `fix(mcp): surface the missing executable path when a browser isn't installed` — clearer error message pointing at the missing browser executable. ([microsoft/playwright#41941](https://github.com/microsoft/playwright/pull/41941))
- `fix(mcp): identify downloads explicitly` — downloads are labeled explicitly in command responses. ([microsoft/playwright#41933](https://github.com/microsoft/playwright/pull/41933))
- `fix(mcp): validate Host and Origin on CDP relay WebSocket upgrades` — hardens the extension relay against unauthorized cross-origin connections. ([microsoft/playwright#42103](https://github.com/microsoft/playwright/pull/42103))
- `fix(mcp): escape user input in codegen output` — special characters in your input are escaped correctly in the generated code. ([microsoft/playwright#41962](https://github.com/microsoft/playwright/pull/41962))
- `fix(mcp): mention PLAYWRIGHT_MCP_EXECUTABLE_PATH in extension not found error` — points at the escape hatch when the extension browser can't be located (e.g. on WSL2). ([microsoft/playwright#42092](https://github.com/microsoft/playwright/issues/42092), [microsoft/playwright#42122](https://github.com/microsoft/playwright/pull/42122))
- `perf(mcp): skip aria snapshot capture when the response discards it` — commands that don't need a snapshot run faster. ([microsoft/playwright#41923](https://github.com/microsoft/playwright/pull/41923))
- The v0.1.17 fix for `goto` crashing on privileged pages (`chrome://…`) was reverted upstream: the crash originates in the browser process itself, and the fix only masked it. ([microsoft/playwright#41931](https://github.com/microsoft/playwright/pull/41931))

## Upgrading

```bash
npm install -g @playwright/cli@0.1.18
```