### PR TITLE
fix(cli): apply update-check policy to installed skill check

### DIFF
--- a/playwright-cli.js
+++ b/playwright-cli.js
@@ -32,14 +32,11 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 main();
 
 async function main() {
-  const command = process.argv.slice(2).find(arg => !arg.startsWith('-'));
-  if (command !== 'install')
-    checkInstalledSkills();
-  await notifyAboutUpdate().catch(() => {});
+  await checkForUpdates().catch(() => {});
   program({ embedderVersion: packageJson.version });
 }
 
-async function notifyAboutUpdate() {
+async function checkForUpdates() {
   if (process.env.NO_UPDATE_NOTIFIER || process.env.CI)
     return;
 
@@ -47,13 +44,14 @@ async function notifyAboutUpdate() {
   const stale = !cache || (Date.now() - cache.lastCheck) > ONE_DAY_MS;
   if (!stale)
     return;
+  writeCache({ lastCheck: Date.now() });
+
+  const command = process.argv.slice(2).find(arg => !arg.startsWith('-'));
+  if (command !== 'install')
+    checkInstalledSkills();
 
   const latest = await fetchLatestVersion();
-  if (!latest)
-    return;
-  writeCache({ lastCheck: Date.now(), latestVersion: latest });
-
-  if (tools.compareSemver(latest, packageJson.version) > 0)
+  if (latest && tools.compareSemver(latest, packageJson.version) > 0)
     printNotice(packageJson.version, latest);
 }
 
@@ -89,13 +87,14 @@ function printNotice(current, latest) {
 }
 
 function cacheFile() {
-  return path.join(registry.defaultRegistryDirectory, 'cli-update-check.json');
+  const dir = process.env.PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST || registry.defaultRegistryDirectory;
+  return path.join(dir, 'cli-update-check.json');
 }
 
 function readCache() {
   try {
     const data = JSON.parse(fs.readFileSync(cacheFile(), 'utf8'));
-    if (typeof data.lastCheck === 'number' && typeof data.latestVersion === 'string')
+    if (typeof data.lastCheck === 'number')
       return data;
   } catch {
   }

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -25,7 +25,7 @@ type CliResult = {
   exitCode: number | null;
 };
 
-async function runCli(...args: string[]): Promise<CliResult> {
+async function runCli(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
   const cliPath = path.join(__dirname, '../playwright-cli.js');
 
   return new Promise<CliResult>((resolve, reject) => {
@@ -36,6 +36,7 @@ async function runCli(...args: string[]): Promise<CliResult> {
       env: {
         ...process.env,
         PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST: test.info().outputPath(),
+        ...env,
       },
       cwd: test.info().outputPath(),
     });
@@ -61,39 +62,44 @@ async function runCli(...args: string[]): Promise<CliResult> {
 }
 
 test('open data URL', async ({}) => {
-  expect(await runCli('open', 'data:text/html,hello', '--persistent')).toEqual(expect.objectContaining({
+  expect(await runCli(['open', 'data:text/html,hello', '--persistent'])).toEqual(expect.objectContaining({
     output: expect.stringContaining('hello'),
     exitCode: 0,
   }));
 
-  expect(await runCli('delete-data')).toEqual(expect.objectContaining({
+  expect(await runCli(['delete-data'])).toEqual(expect.objectContaining({
     output: expect.stringContaining('Deleted user data for'),
     exitCode: 0,
   }));
 });
 
 test('warns when installed skill is out of date', async ({}) => {
-  expect(await runCli('install', '--skills')).toEqual(expect.objectContaining({
+  expect(await runCli(['install', '--skills'], { NO_UPDATE_NOTIFIER: '1' })).toEqual(expect.objectContaining({
     exitCode: 0,
   }));
 
   const skillFile = path.join(test.info().outputPath(), '.claude', 'skills', 'playwright-cli', 'SKILL.md');
   fs.appendFileSync(skillFile, 'x');
 
-  expect(await runCli('--help')).toEqual(expect.objectContaining({
+  const env = { CI: '', NO_UPDATE_NOTIFIER: '' };
+  expect(await runCli(['--help'], env)).toEqual(expect.objectContaining({
     error: expect.stringContaining('does not match the tool version'),
+  }));
+
+  expect(await runCli(['--help'], env)).toEqual(expect.objectContaining({
+    error: expect.not.stringContaining('does not match the tool version'),
   }));
 });
 
 test('does not warn when installed skill only differs in line endings', async ({}) => {
-  expect(await runCli('install', '--skills')).toEqual(expect.objectContaining({
+  expect(await runCli(['install', '--skills'], { NO_UPDATE_NOTIFIER: '1' })).toEqual(expect.objectContaining({
     exitCode: 0,
   }));
 
   const skillFile = path.join(test.info().outputPath(), '.claude', 'skills', 'playwright-cli', 'SKILL.md');
   fs.writeFileSync(skillFile, fs.readFileSync(skillFile, 'utf8').replace(/\n/g, '\r\n'));
 
-  expect(await runCli('--help')).toEqual(expect.objectContaining({
+  expect(await runCli(['--help'], { CI: '', NO_UPDATE_NOTIFIER: '' })).toEqual(expect.objectContaining({
     error: expect.not.stringContaining('does not match the tool version'),
   }));
 });


### PR DESCRIPTION
## Summary
- The installed-skill check now honors `NO_UPDATE_NOTIFIER`/`CI` and runs at most once a day, sharing the update notifier's policy.

Fixes https://github.com/microsoft/playwright/issues/42233