### PR TITLE
fix(cli): call defaultRegistryDirectory() when resolving the cache file

### DIFF
--- a/playwright-cli.js
+++ b/playwright-cli.js
@@ -87,13 +87,14 @@ function printNotice(current, latest) {
 }
 
 function cacheFile() {
-  const dir = process.env.PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST || registry.defaultRegistryDirectory;
+  const dir = process.env.PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST || registry.defaultRegistryDirectory();
   return path.join(dir, 'cli-update-check.json');
 }
 
 function readCache() {
+  const file = cacheFile();
   try {
-    const data = JSON.parse(fs.readFileSync(cacheFile(), 'utf8'));
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
     if (typeof data.lastCheck === 'number')
       return data;
   } catch {
@@ -105,8 +106,8 @@ function readCache() {
  * @param {*} data
  */
 function writeCache(data) {
+  const file = cacheFile();
   try {
-    const file = cacheFile();
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(file, JSON.stringify(data));
   } catch {

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -103,3 +103,36 @@ test('does not warn when installed skill only differs in line endings', async ({
     error: expect.not.stringContaining('does not match the tool version'),
   }));
 });
+
+test('caches the update check in the default registry directory', async ({}) => {
+  // Redirect the home/cache directories so the real user cache is untouched, and
+  // leave PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST empty so the default path is used.
+  const home = test.info().outputPath('home');
+  fs.mkdirSync(home, { recursive: true });
+  const env = {
+    CI: '',
+    NO_UPDATE_NOTIFIER: '',
+    PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST: '',
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CACHE_HOME: path.join(home, '.cache'),
+    LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+  };
+
+  expect(await runCli(['--version'], env)).toEqual(expect.objectContaining({ exitCode: 0 }));
+
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory())
+        walk(full);
+      else if (entry.name === 'cli-update-check.json')
+        found.push(full);
+    }
+  };
+  walk(home);
+
+  expect(found).toHaveLength(1);
+  expect(JSON.parse(fs.readFileSync(found[0], 'utf8')).lastCheck).toEqual(expect.any(Number));
+});


### PR DESCRIPTION
I am interested in the `playwright-cli` version command because this version control code worked once one day and set a note for update control, but this control does not write the version to the document and always goes to control

I called the `defaultRegistryDirectory()` method after starting the writer for the doc, and it didn’t go to the web for version control; it read the cache doc.

## What is broken

The update check is meant to run at most once a day, cached in `cli-update-check.json`. That cache file is never written, so **every** CLI invocation hits `registry.npmjs.org` and re-runs the installed-skill check.

## Root cause

`registry.defaultRegistryDirectory` became a function in microsoft/playwright#41942 (2026-07-23) and reached this repo with the roll to `1.63.0-alpha-2026-08-05` (#442). `cacheFile()` still used it as a string:

```js
const dir = process.env.PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST || registry.defaultRegistryDirectory;
return path.join(dir, 'cli-update-check.json');
```

`path.join()` throws a `TypeError`, which `readCache()` and `writeCache()` swallow in their bare `catch {}` — so the failure reads as "no cache yet" and the check is always stale.

## Impact

Measured with `--version`, before → after:

| network | before | after |
|---|---|---|
| normal | ~480ms | ~125ms |
| firewall that drops packets to npm | ~1650ms | ~125ms |

The second row is the 1500ms `AbortController` timeout in `fetchLatestVersion()`, paid on every command.

## Why CI did not catch it

`runCli()` always sets `PLAYWRIGHT_CLI_INSTALLATION_FOR_TEST`, so the `||` short-circuits and the broken branch never runs. The added test points `HOME` at a temp directory, leaves that variable empty, and asserts the cache file is written.

## Changes

- call `registry.defaultRegistryDirectory()`
- regression test covering the default cache path
- hoist `cacheFile()` out of the `try` blocks so only I/O and parse errors are swallowed there, instead of masking a path-computation bug as "no cache" (happy to drop this if you prefer the fix alone)

asist: Claude opus 5