### PR TITLE
chore: roll Playwright to 1.63.0-alpha-2026-08-31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 # Ignore self-skill which is a build artifact
 .claude/skills/playwright-cli/
 .npmrc
+# Playwright CLI output (may contain credentials)
+.playwright-cli/

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ playwright-cli run-code <code>          # run playwright code snippet
 playwright-cli run-code --filename=f    # run playwright code from a file
 playwright-cli tracing-start            # start trace recording
 playwright-cli tracing-stop             # stop trace recording
+playwright-cli recording-start          # record user actions in the browser
+playwright-cli recording-stop           # stop recording, print actions as Playwright code
 playwright-cli video-start [filename]   # start video recording
 playwright-cli video-chapter <title>    # add a chapter marker to the video
 playwright-cli video-show-actions       # annotate each action with a callout in the video

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.63.0-alpha-2026-08-05",
-        "playwright-core": "1.63.0-alpha-2026-08-05"
+        "playwright": "1.63.0-alpha-2026-08-31",
+        "playwright-core": "1.63.0-alpha-2026-08-31"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.63.0-alpha-2026-08-05",
+        "@playwright/test": "1.63.0-alpha-2026-08-31",
         "@types/node": "^25.2.1"
       },
       "engines": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.63.0-alpha-2026-08-05",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0-alpha-2026-08-05.tgz",
-      "integrity": "sha512-Q63UaqUDAAwdrGwYjvlLXsfltkUkmRqqwkZ7SSmY3qDGAH2gUcIHWvHauU5xnWhBrIVHej07sGUbErS3QL39tw==",
+      "version": "1.63.0-alpha-2026-08-31",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0-alpha-2026-08-31.tgz",
+      "integrity": "sha512-sNAYSkzbTC67x/v4ZekJ5ZzBFhSaHGc5t8+/3lqZI9LSvtYWVC+L2bHDbfFIhVXBjtl+1v+rg9Fdx+Rx3w2E8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.63.0-alpha-2026-08-05"
+        "playwright": "1.63.0-alpha-2026-08-31"
       },
       "bin": {
         "playwright": "cli.js"
@@ -49,42 +49,25 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/playwright": {
-      "version": "1.63.0-alpha-2026-08-05",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-05.tgz",
-      "integrity": "sha512-zbGZUK+JYkoDV3cUgfvh2czTBJL34Gmz5gHVI25xiIpvYSR17Q1M7TS8hnwECUe+IkKaeXbKrSyJTyogm2DVWw==",
+      "version": "1.63.0-alpha-2026-08-31",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-31.tgz",
+      "integrity": "sha512-3XAsuznfu8jBVJ4QxdGvBkt0+b8ZFwuwJYyOfiIw5ZjUOrNLNRhKxzLzLuydou3gJ9c6eMwVqgzdiOwhy54Kzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-alpha-2026-08-05"
+        "playwright-core": "1.63.0-alpha-2026-08-31"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.63.0-alpha-2026-08-05",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-05.tgz",
-      "integrity": "sha512-YussvUybTfBtyYbGXWh43f+5kNP03wg98M6mu4DphYET7PSbNVajsdLGjWE1xrsjqOw32i2wFlRP7U5mcOpMZg==",
+      "version": "1.63.0-alpha-2026-08-31",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-31.tgz",
+      "integrity": "sha512-1ek0Lyr12h6jcs/WTcNoVtzZkQp7D/90PsMuBW/Rm6h3AsWAbzpqj0geMv8+8Tzzr9CSUYvg9kznrVZINQMXXw==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.63.0-alpha-2026-08-05",
+    "@playwright/test": "1.63.0-alpha-2026-08-31",
     "@types/node": "^25.2.1"
   },
   "dependencies": {
-    "playwright": "1.63.0-alpha-2026-08-05",
-    "playwright-core": "1.63.0-alpha-2026-08-05"
+    "playwright": "1.63.0-alpha-2026-08-31",
+    "playwright-core": "1.63.0-alpha-2026-08-31"
   },
   "bin": {
     "playwright-cli": "playwright-cli.js"

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -165,6 +165,11 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
+
+# record user actions in the browser, print them as Playwright code on stop
+playwright-cli recording-start
+playwright-cli recording-stop
+
 playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop

--- a/skills/playwright-cli/references/tracing.md
+++ b/skills/playwright-cli/references/tracing.md
@@ -19,7 +19,7 @@ playwright-cli tracing-stop
 
 ## Trace Output Files
 
-When you start tracing, Playwright creates a `traces/` directory with several files:
+When you start tracing, Playwright creates a `.playwright-cli/traces/` directory with several files:
 
 ### `trace-{timestamp}.trace`
 


### PR DESCRIPTION
Roll Playwright to 1.63.0-alpha-2026-08-31.

- Bump `playwright`, `playwright-core` and `@playwright/test` to 1.63.0-alpha-2026-08-31.
- Regenerate the skill: new `recording-start` / `recording-stop` commands, trace output moved to `.playwright-cli/traces/`.
- Document `recording-start` / `recording-stop` in the README.
- Pick up the `.gitignore` entry for `.playwright-cli/` written by `install --skills`.