### PR TITLE
devops: restore npm publishing from GitHub Actions

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,10 +1,9 @@
-# Publishes @playwright/cli via ESRP:
-# - @next (alpha with current timestamp) from main, on manual trigger
-# - @latest from v* release tags (pushed when a GitHub release is published)
-trigger:
-  tags:
-    include:
-    - v*
+# Publishes @playwright/cli via ESRP. Manual trigger only, regular publishing
+# is done from GitHub Actions, see .github/workflows/publish.yml.
+# Depending on the selected ref, a manual run publishes:
+# - @next (alpha with current timestamp) from main
+# - @latest from v* release tags
+trigger: none
 
 pr: none
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC npm publishing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish


### PR DESCRIPTION
## Summary
- Release publishing goes back to the GitHub Actions workflow with OIDC trusted publishing and provenance.
- The ESRP pipeline stays available for manual on-demand runs only (no automatic triggers).