### PR TITLE
feat: add Agent Plugins 1.0 package

### DIFF
--- a/.claude/skills/dev/release.md
+++ b/.claude/skills/dev/release.md
@@ -4,7 +4,7 @@ A release is a `chore: mark v<next-patch>` commit whose PR body is the release n
 
 ## Steps
 
-1. **Bump the patch version** in `package.json` (e.g. `0.1.7` → `0.1.8`), then `npm install` to sync `package-lock.json`. This is the entry point — everything else (branch name, PR title, release notes filename) keys off the new version.
+1. **Bump the patch version** in `package.json` and `plugin.json` (e.g. `0.1.7` → `0.1.8`), then `npm install` to sync `package-lock.json`. This is the entry point — everything else (branch name, PR title, release notes filename) keys off the new version.
 
 2. **Find the baseline.** The previous release is the last `chore: mark v...` commit on `main`. Read the Playwright version pinned at that commit — that's the baseline for the diff.
    ```bash
@@ -59,7 +59,7 @@ A release is a `chore: mark v<next-patch>` commit whose PR body is the release n
 8. **Commit, push, open PR.** The PR body is the contents of the release notes file (no `#` header, no filename).
    ```bash
    git checkout -b mark-v<version>
-   git add package.json package-lock.json
+   git add package.json package-lock.json plugin.json
    git commit -m "chore: mark v<version>"
    git push -u origin mark-v<version>
    gh pr create --repo microsoft/playwright-cli \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,14 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - name: Validate plugin.json version matches package.json
+        run: |
+          node -e "
+            const pkg = require('./package.json');
+            const plugin = require('./plugin.json');
+            if (plugin.version !== pkg.version) {
+              console.error(\`plugin.json is out of sync with package.json: plugin.version=\${plugin.version} != package.version=\${pkg.version}\`);
+              process.exit(1);
+            }
+          "
       - run: npm publish

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "playwright-cli",
+  "version": "0.1.19",
+  "description": "Drive a browser from the command line with playwright-cli: automate interactions, test web pages and work with Playwright tests. Requires the @playwright/cli package to be installed.",
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "homepage": "https://github.com/microsoft/playwright-cli",
+  "repository": "https://github.com/microsoft/playwright-cli",
+  "license": "Apache-2.0",
+  "keywords": [
+    "playwright",
+    "browser",
+    "automation",
+    "cli",
+    "testing",
+    "skills"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `plugin.json` at the repository root so clients that support [Agent Plugins 1.0](https://agent-plugins.org) (VS Code, Copilot CLI, Cursor, Codex, Kiro) can install the `playwright-cli` skill from the repository URL; the existing `skills/playwright-cli/` directory already matches the spec layout
- The publish workflow validates the `plugin.json` version against `package.json`

Companion to https://github.com/microsoft/playwright-mcp/pull/1746